### PR TITLE
RF: use our Runner for dpkg-query execution

### DIFF
--- a/niceman/retrace/packagemanagers.py
+++ b/niceman/retrace/packagemanagers.py
@@ -118,7 +118,11 @@ class DpkgManager(PackageManager):
 
         # Note, we must split after ": " instead of ":" in case the
         # package name includes an architecture (like "zlib1g:amd64")
-        pkg = out.decode().split(': ', 1)[0]
+        try:
+            out = out.decode()
+        except AttributeError:
+            pass
+        pkg = out.split(': ', 1)[0]
         lgr.debug("Identified file %r to belong to package %s", filename, pkg)
         return pkg
 

--- a/niceman/retrace/rpzutil.py
+++ b/niceman/retrace/rpzutil.py
@@ -150,7 +150,7 @@ def get_system_files(config):
     Return
     ------
     set
-        System fles from the configuration
+        Files listed in the configuration
     """
 
     files = set()


### PR DESCRIPTION
was skimming through the code and decided to change a little -- better altogether to use our Runner helper so we have a central single point of interfacing with external commands.  Also IMHO better to not swallow blindly failed execution runs -- who knows what could have gone wrong