### PR TITLE
ENH: Pull out package origins into a separate configuration item

### DIFF
--- a/niceman/retrace/packagemanagers.py
+++ b/niceman/retrace/packagemanagers.py
@@ -145,8 +145,8 @@ class DpkgManager(PackageManager):
         # origin and site, and make sure it is unique (by adding a number)
         for o in origins:
             i = 0
-            name = "apt_" + o.get("origin") + "_" + o.get("site") + "_" + \
-                   o.get("archive") + "_"
+            name = "apt_" + o.get("origin") + "_" + o.get("archive") + "_" + \
+                   o.get("component") + "_"
             # See if the name is unique (and increment the number until it is)
             while (name + str(i)) in origin_name_set:
                 i += 1
@@ -222,6 +222,7 @@ class DpkgManager(PackageManager):
         # prep our pkg object:
         pkg = collections.OrderedDict()
         pkg["name"] = pkgname
+        pkg["type"] = "dpkg"
         pkg["version"] = pkg_info.installed.version
         pkg["candidate"] = pkg_info.candidate.version
         pkg["size"] = pkg_info.installed.size

--- a/niceman/retrace/packagemanagers.py
+++ b/niceman/retrace/packagemanagers.py
@@ -159,8 +159,13 @@ class DpkgManager(PackageManager):
 
         # Now update the origins with their name and type
         for i, o in enumerate(origins):
-            o["name"] = origin_names[i]
-            o["type"] = "apt"
+            new_o = collections.OrderedDict()
+            new_o["name"] = origin_names[i]
+            new_o["type"] = "apt"
+            new_o.update(o)
+            origins[i] = new_o
+        # Now sort the origins by the name
+        origins = sorted(origins, key=lambda k: k["name"])
 
         return origins
 
@@ -249,6 +254,7 @@ def identify_packages(files):
     Returns
     -------
     packages : list of Package
+    origin : list of Origin
     unknown_files : list of str
       Files which were not determined to belong to some package
     """

--- a/niceman/retrace/packagemanagers.py
+++ b/niceman/retrace/packagemanagers.py
@@ -12,6 +12,7 @@ from __future__ import unicode_literals
 
 import collections
 import os
+from os.path import join as opj
 import time
 from logging import getLogger
 from six import viewvalues
@@ -287,12 +288,12 @@ class DpkgManager(PackageManager):
                 for relfile in ['InRelease', 'Release']:
                     name = ((apt_pkg.uri_to_filename(uri)) +
                             "dists_%s_%s" % (archive, relfile))
-                    if os.path.exists(dirname + name):
+                    if os.path.exists(opj(dirname, name)):
                         if rfile:
                             raise MultipleReleaseFileMatch(
                                 "More than one release file found for %s %s" %
                                 (site, archive))
-                        rfile = dirname + name
+                        rfile = opj(dirname, name)
 
         # Now extract and format the date from the release file
         rdate = None

--- a/niceman/retrace/packagemanagers.py
+++ b/niceman/retrace/packagemanagers.py
@@ -29,8 +29,11 @@ from niceman.cmd import CommandError
 
 lgr = getLogger('niceman.api.retrace')
 
-# Pick a conservative max command-line (instead of using os)
-_MAX_LEN_CMDLINE = 2048
+# Pick a conservative max command-line
+try:
+    _MAX_LEN_CMDLINE = os.sysconf(str("SC_ARG_MAX")) // 2
+except ValueError:
+    _MAX_LEN_CMDLINE = 2048
 
 # Note: The following was derived from ReproZip's PkgManager class
 # (Revised BSD License)

--- a/niceman/retrace/packagemanagers.py
+++ b/niceman/retrace/packagemanagers.py
@@ -157,9 +157,8 @@ class DpkgManager(PackageManager):
     @staticmethod
     def _create_origin(o, used_names):
         # Create a unique name for the origin
-        name_fmt = "apt_" + o.get("origin") + "_" + \
-                   o.get("archive") + "_" + \
-                   o.get("component") + "_%d"
+        name_fmt = "apt_%s_%s_%s_%%d" % (o.get("origin"), o.get("archive"),
+                                         o.get("component"))
         name = utils.generate_unique_name(name_fmt,
                                           used_names)
         # Remember the created name

--- a/niceman/retrace/packagemanagers.py
+++ b/niceman/retrace/packagemanagers.py
@@ -270,6 +270,9 @@ class DpkgManager(PackageManager):
         lgr.debug("Found package %s", pkg)
         return pkg
 
+    class MultipleReleaseFileMatch(RuntimeError):
+        pass
+
     def _find_release_date(self, site, archive):
         if not site:
             return None
@@ -281,13 +284,13 @@ class DpkgManager(PackageManager):
         # If we want to avoid using cache._list, we can call
         # apt_pkg.SourceList() directly
         for uri in set([metaindex.uri for metaindex in cache._list.list]):
-            if site in uri:
+            if ("//" + site + "/") in uri:
                 for relfile in ['InRelease', 'Release']:
                     name = ((apt_pkg.uri_to_filename(uri)) +
                             "dists_%s_%s" % (archive, relfile))
                     if os.path.exists(dirname + name):
                         if rfile:
-                            lgr.warning(
+                            raise self.MultipleReleaseFileMatch(
                                 "More than one release file found for %s %s" %
                                 (site, archive))
                         rfile = dirname + name

--- a/niceman/retrace/packagemanagers.py
+++ b/niceman/retrace/packagemanagers.py
@@ -21,6 +21,7 @@ import pytz
 from datetime import datetime
 
 import niceman.utils as utils
+from niceman.support.exceptions import MultipleReleaseFileMatch
 
 try:
     import apt
@@ -271,9 +272,6 @@ class DpkgManager(PackageManager):
         lgr.debug("Found package %s", pkg)
         return pkg
 
-    class MultipleReleaseFileMatch(RuntimeError):
-        pass
-
     def _find_release_date(self, site, archive):
         if not site:
             return None
@@ -291,7 +289,7 @@ class DpkgManager(PackageManager):
                             "dists_%s_%s" % (archive, relfile))
                     if os.path.exists(dirname + name):
                         if rfile:
-                            raise self.MultipleReleaseFileMatch(
+                            raise MultipleReleaseFileMatch(
                                 "More than one release file found for %s %s" %
                                 (site, archive))
                         rfile = dirname + name

--- a/niceman/retrace/packagemanagers.py
+++ b/niceman/retrace/packagemanagers.py
@@ -15,6 +15,7 @@ import os
 import time
 from logging import getLogger
 from six import viewvalues
+from six.moves.urllib.parse import urlparse
 
 import pytz
 from datetime import datetime
@@ -284,7 +285,7 @@ class DpkgManager(PackageManager):
         # If we want to avoid using cache._list, we can call
         # apt_pkg.SourceList() directly
         for uri in set([metaindex.uri for metaindex in cache._list.list]):
-            if ("//" + site + "/") in uri:
+            if site == urlparse(uri).netloc:
                 for relfile in ['InRelease', 'Release']:
                     name = ((apt_pkg.uri_to_filename(uri)) +
                             "dists_%s_%s" % (archive, relfile))

--- a/niceman/retrace/packagemanagers.py
+++ b/niceman/retrace/packagemanagers.py
@@ -16,6 +16,7 @@ from six import viewvalues
 from logging import getLogger
 import time
 import pytz
+import niceman.utils as utils
 from datetime import datetime
 try:
     import apt
@@ -144,15 +145,13 @@ class DpkgManager(PackageManager):
         # Iterate through each origin, creating a name out of the
         # origin and site, and make sure it is unique (by adding a number)
         for o in origins:
-            i = 0
             name = "apt_" + o.get("origin") + "_" + o.get("archive") + "_" + \
                    o.get("component") + "_"
             # See if the name is unique (and increment the number until it is)
-            while (name + str(i)) in origin_name_set:
-                i += 1
+            name = utils.generate_unique_name(name + "%d", origin_name_set)
             # store the new name into our origin list and set
-            origin_name_set.add(name + str(i))
-            origin_names.append(name + str(i))
+            origin_name_set.add(name)
+            origin_names.append(name)
 
         # Now replace the origins with our created names
         # TODO: replace iterative search with a hash lookup?

--- a/niceman/retrace/rpzutil.py
+++ b/niceman/retrace/rpzutil.py
@@ -64,11 +64,14 @@ def identify_packages(config):
     # Immediately clone the configuration
     files = get_system_files(config)
 
-    (packages, unidentified_files) = packagemanagers.identify_packages(
-        list(files))
+    (packages, origins, unidentified_files) = \
+        packagemanagers.identify_packages(list(files))
 
     # Update reprozip package assignment
     config['packages'] = packages
+
+    # Update reprozip package assignment
+    config['origins'] = origins
 
     # set any files not identified
     config['other_files'] = list(unidentified_files)
@@ -105,6 +108,10 @@ def write_config(output, config):
 
     c = "\n# Runs: Commands and related environment variables\n\n"
     write_config_key(output, envconfig, "runs", c)
+
+    c = "\n# Package Origins \n\n"
+    write_config_key(output, envconfig, "origins", c)
+
 
     c = "\n# Packages \n\n"
     write_config_key(output, envconfig, "packages", c)

--- a/niceman/retrace/rpzutil.py
+++ b/niceman/retrace/rpzutil.py
@@ -112,7 +112,6 @@ def write_config(output, config):
     c = "\n# Package Origins \n\n"
     write_config_key(output, envconfig, "origins", c)
 
-
     c = "\n# Packages \n\n"
     write_config_key(output, envconfig, "packages", c)
 

--- a/niceman/retrace/tests/test_packagemanagers.py
+++ b/niceman/retrace/tests/test_packagemanagers.py
@@ -19,7 +19,8 @@ def test_identify_packages():
              "/usr/share/bug/vim/script",
              "/home/butch"]
     # TODO: Mock I/O and detect correct analysis
-    packages, files = identify_packages(files)
+    packages, origins, files = identify_packages(files)
     pprint(files)
+    pprint(origins)
     pprint(packages)
     assert True

--- a/niceman/support/exceptions.py
+++ b/niceman/support/exceptions.py
@@ -54,3 +54,8 @@ class MissingConfigError(RuntimeError):
 class MissingConfigFileError(RuntimeError):
     """To be raised when missing the configuration file"""
     pass
+
+
+class MultipleReleaseFileMatch(RuntimeError):
+    """Multiple release files were matched while retracing on Debian"""
+    pass

--- a/niceman/tests/test_utils.py
+++ b/niceman/tests/test_utils.py
@@ -41,6 +41,7 @@ from ..utils import make_tempfile
 from ..utils import on_windows
 from ..utils import _path_
 from ..utils import unicode
+from ..utils import generate_unique_name
 
 from nose.tools import ok_, eq_, assert_false, assert_equal, assert_true
 
@@ -413,3 +414,12 @@ def test_unicode():
         s = "mytest"
         s2 = unicode(s)
         assert(s2 == __builtin__.unicode(s))
+
+def test_generate_unique_set():
+    names = set()
+    n = generate_unique_name("test_%d",names)
+    assert(n == "test_0")
+    names.add(n)
+    n = generate_unique_name("test_%d",names)
+    assert(n == "test_1")
+    

--- a/niceman/tests/test_utils.py
+++ b/niceman/tests/test_utils.py
@@ -434,4 +434,3 @@ def test_hashable_dict():
     d[key_a] = 1
     assert(key_b in d)
     assert(key_c not in d)
-

--- a/niceman/tests/test_utils.py
+++ b/niceman/tests/test_utils.py
@@ -24,7 +24,7 @@ from os.path import isabs, expandvars, expanduser
 from collections import OrderedDict
 
 from ..dochelpers import exc_str
-from ..utils import updated
+from ..utils import updated, HashableDict
 from os.path import join as opj, abspath, exists
 from ..utils import rotree, swallow_outputs, swallow_logs, setup_exceptionhook, md5sum
 from ..utils import getpwd, chpwd
@@ -424,3 +424,14 @@ def test_generate_unique_set():
     names.add(n)
     n = generate_unique_name("test_%d", names)
     assert(n == "test_1")
+
+
+def test_hashable_dict():
+    key_a = HashableDict({"a": 1, "b": "test"})
+    key_b = HashableDict({"a": 1, "b": "test"})
+    key_c = HashableDict({"a": "dog", "b": "boo"})
+    d = dict()
+    d[key_a] = 1
+    assert(key_b in d)
+    assert(key_c not in d)
+

--- a/niceman/tests/test_utils.py
+++ b/niceman/tests/test_utils.py
@@ -404,8 +404,9 @@ def test_path_():
         p = 'a/b/c'
         assert(_path_(p) is p)  # nothing is done to it whatsoever
 
+
 def test_unicode():
-    if (PY3):
+    if PY3:
         s = b"mytest"
         s2 = "mytest"
         assert(unicode(s) == s2)
@@ -415,11 +416,11 @@ def test_unicode():
         s2 = unicode(s)
         assert(s2 == __builtin__.unicode(s))
 
+
 def test_generate_unique_set():
     names = set()
-    n = generate_unique_name("test_%d",names)
+    n = generate_unique_name("test_%d", names)
     assert(n == "test_0")
     names.add(n)
-    n = generate_unique_name("test_%d",names)
+    n = generate_unique_name("test_%d", names)
     assert(n == "test_1")
-    

--- a/niceman/utils.py
+++ b/niceman/utils.py
@@ -898,7 +898,22 @@ def unicode(s):
 
 
 def generate_unique_name(pattern, nameset):
-    """Create a unique numbered name from a pattern and a set"""
+    """Create a unique numbered name from a pattern and a set
+
+    Parameters
+    ----------
+    pattern: str
+      The pattern for the name (to be used with %) that includes one %d
+      location
+    nameset: collection
+      Collection (set or list) of existing names. If the generated name is
+      used, then add the name to the nameset.
+
+    Returns
+    -------
+    str
+      The generated unique name
+    """
     i = 0
     while True:
         n = pattern % i

--- a/niceman/utils.py
+++ b/niceman/utils.py
@@ -883,6 +883,7 @@ def _path_(p):
         # Assume that all others as POSIX compliant so nothing to be done
         return p
 
+
 def unicode(s):
     """Given a str type, convert to unicode"""
     if PY3:
@@ -894,6 +895,7 @@ def unicode(s):
             raise TypeError("Incorrect type for unicode()")
     else:
         return __builtin__.unicode(s)
+
 
 def generate_unique_name(pattern, nameset):
     """Create a unique numbered name from a pattern and a set"""

--- a/niceman/utils.py
+++ b/niceman/utils.py
@@ -895,4 +895,13 @@ def unicode(s):
     else:
         return __builtin__.unicode(s)
 
+def generate_unique_name(pattern, nameset):
+    """Create a unique numbered name from a pattern and a set"""
+    i = 0
+    while True:
+        n = pattern % i
+        i += 1
+        if n not in nameset:
+            return n
+
 lgr.log(5, "Done importing niceman.utils")

--- a/niceman/utils.py
+++ b/niceman/utils.py
@@ -906,4 +906,11 @@ def generate_unique_name(pattern, nameset):
         if n not in nameset:
             return n
 
+
+# http://stackoverflow.com/questions/1151658/python-hashable-dicts
+class HashableDict(dict):
+    """Dict that can be used as keys"""
+    def __hash__(self):
+        return hash(frozenset(self.values()))
+
 lgr.log(5, "Done importing niceman.utils")

--- a/niceman/utils.py
+++ b/niceman/utils.py
@@ -902,7 +902,7 @@ def generate_unique_name(pattern, nameset):
 
     Parameters
     ----------
-    pattern: str
+    pattern: basestring
       The pattern for the name (to be used with %) that includes one %d
       location
     nameset: collection


### PR DESCRIPTION
This update pulls origins into a separate configuration item.  For example, after retracing you will find a section that looks like:

```
origins:
- {archive: xenial, component: universe, label: Ubuntu, name: apt_Ubuntu_us.archive.ubuntu.com_xenial_0,
  origin: Ubuntu, site: us.archive.ubuntu.com, type: apt}
- {archive: now, component: now, label: '', name: apt___now_0, origin: '', site: '',
  type: apt}
- {archive: xenial, component: main, label: Ubuntu, name: apt_Ubuntu_us.archive.ubuntu.com_xenial_1,
  origin: Ubuntu, site: us.archive.ubuntu.com, type: apt}
```

And packages now refer to the names within the origins:

```
packages:
- name: fsl-5.0-core
  version: 5.0.9-3~nd16.04+1
  candidate: 5.0.9-3~nd16.04+1
  size: 8122764
  architecture: amd64
  md5: 310a086529df52f1291ba09cf9335dbe
  sha1: efe9c98dd3ae2b2466fed38fd1b64086c26918de
  sha256: ea60d277f4b2c9da478a76ef708437c4eb235a0022f41e560fc79b2036a66aec
  source_name: fsl
  source_version: 5.0.9-3~nd16.04+1
  files: [/usr/lib/fsl/5.0/bet, /usr/lib/fsl/5.0, /usr/lib/fsl/5.0/libprob.so, /usr/lib/fsl/5.0/fslmerge,
    ...
    /usr/lib/fsl/5.0/libnewimage.so, /usr/lib/fsl/5.0/remove_ext, /usr/lib/fsl/5.0/fsl_sub]
  install_date: '2016-12-29 21:41:46.603318+00:00'
  version_table:
  - origins: [apt_NeuroDebian_neuro.debian.net_xenial_0, apt___now_0]
    version: 5.0.9-3~nd16.04+1
  - origins: [apt_Ubuntu_us.archive.ubuntu.com_xenial_2]
    version: 5.0.8-5
```

