### PR TITLE
NF: trace files belonging to VCS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,8 @@ before_install:
   # The ultimate one-liner setup for NeuroDebian repository
   - bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
   - travis_retry sudo apt-get update -qq
+  - git config --global user.email "test@travis.land"
+  - git config --global user.name "Travis Almighty"
 
 install:
   # all mess below to get an elderly python-apt installed on elderly precise within python env -- we must build it

--- a/niceman/interface/retrace.py
+++ b/niceman/interface/retrace.py
@@ -38,7 +38,7 @@ class Retrace(Interface):
             doc="ReproZip YML file to be analyzed",
             metavar='SPEC',
             # nargs="+",
-            constraints=EnsureStr(),
+            constraints=EnsureStr() | EnsureNone(),
         ),
         path=Parameter(
             args=("path",),

--- a/niceman/interface/retrace.py
+++ b/niceman/interface/retrace.py
@@ -6,12 +6,13 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""Analyzes ReproZip YML configuration to gather detailed package information
+"""Analyze ReproZip YML configuration to gather detailed package information
 """
 import sys
 from .base import Interface
 from ..support.param import Parameter
 from ..support.constraints import EnsureStr
+from ..support.constraints import EnsureNone
 from ..support.exceptions import InsufficientArgumentsError
 from ..retrace import rpzutil
 from logging import getLogger
@@ -22,7 +23,7 @@ lgr = getLogger('niceman.api.retrace')
 
 
 class Retrace(Interface):
-    """Analyzes ReproZip files to gather detailed package information
+    """Analyze known (e.g. ReproZip) trace files or just paths to gather detailed package information
 
     Examples
     --------
@@ -36,19 +37,35 @@ class Retrace(Interface):
             args=("--spec",),
             doc="ReproZip YML file to be analyzed",
             metavar='SPEC',
-            nargs="+",
+            # nargs="+",
             constraints=EnsureStr(),
+        ),
+        path=Parameter(
+            args=("path",),
+            metavar="PATH",
+            doc="""path(s) to be traced.  If spec is provided, would trace them
+            after tracing the spec""",
+            nargs="*",
+            constraints=EnsureStr() | EnsureNone()),
+        output_file=Parameter(
+            args=("-o", "--output-file",),
+            doc="Output file.  If not specified - printed to stdout",
+            metavar='output_file',
+            constraints=EnsureStr() | EnsureNone(),
         ),
     )
 
     @staticmethod
-    def __call__(spec):
+    def __call__(path=None, spec=None, output_file=None):
 
-        if not spec:
-            raise InsufficientArgumentsError("Need at least a single --spec")
+        if not (spec or path):
+            raise InsufficientArgumentsError("Need at least a single --spec or a file")
 
-        filename = spec[0]
-        lgr.info("reading filename " + filename)
-        config = rpzutil.read_reprozip_yaml(filename)
-        rpzutil.identify_packages(config)
-        rpzutil.write_config(sys.stdout, config)
+        if spec:
+            lgr.info("reading spec file %s ", spec)
+            input_config = rpzutil.read_reprozip_yaml(spec)
+        else:
+            input_config = {}
+
+        config = rpzutil.identify_packages(input_config, path)
+        rpzutil.write_config(output_file or sys.stdout, config)

--- a/niceman/interface/tests/test_retrace.py
+++ b/niceman/interface/tests/test_retrace.py
@@ -30,4 +30,4 @@ def test_retrace():
                 '--spec', REPROZIP_SPEC_YML_FILENAME,
                 ]
         main(args)
-        assert_in("reading filename " + REPROZIP_SPEC_YML_FILENAME, log.lines)
+        assert_in("reading spec file " + REPROZIP_SPEC_YML_FILENAME, log.lines)

--- a/niceman/log.py
+++ b/niceman/log.py
@@ -153,7 +153,10 @@ class ColorFormatter(logging.Formatter):
         if self._tb:
             record.msg = self._tb() + "  " + record.msg
 
-        return logging.Formatter.format(self, record)
+        try:
+            return logging.Formatter.format(self, record)
+        except:
+            import pdb; pdb.set_trace()
 
 
 class LoggerHelper(object):

--- a/niceman/retrace/packagemanagers.py
+++ b/niceman/retrace/packagemanagers.py
@@ -97,6 +97,10 @@ class PackageManager(object):
 
         file_to_package_dict = self._get_packages_for_files(files)
         for f in files:
+            if not os.path.lexists(f):
+                lgr.warning(
+                    "Provided file %s doesn't exist, spec might be incomplete",
+                    f)
             # Stores the file
             if f not in file_to_package_dict:
                 unknown_files.add(f)
@@ -348,7 +352,7 @@ def identify_packages(files):
         (packages_, unknown_files) = manager.search_for_files(files_to_consider)
         origins += manager.identify_package_origins(packages_)
         lgr.debug("Assigning files to packages by %s took %f seconds",
-                  (manager, time.time() - begin))
+                  manager, time.time() - begin)
         packages += packages_
         files_to_consider = unknown_files
 

--- a/niceman/retrace/tests/test_packagemanagers.py
+++ b/niceman/retrace/tests/test_packagemanagers.py
@@ -71,8 +71,13 @@ def test_find_release_file():
 
 @with_tempfile(mkdir=True)
 def test_detached_git(repo):
+    import os
     from niceman.cmd import Runner
-    runner = Runner(env={'LC_ALL': 'C'}, cwd=repo)
+    env = os.environ.copy()
+    env['LC_ALL'] = 'C'
+    runner = Runner(env=env, cwd=repo)
+    assert runner('git config user.name')[0], "git env should be set"
+    assert runner('git config user.email')[0], "git env should be set"
     runner('git init')
 
     # should be good enough not to crash

--- a/niceman/retrace/tests/test_packagemanagers.py
+++ b/niceman/retrace/tests/test_packagemanagers.py
@@ -6,10 +6,14 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+
+from os.path import lexists
+from os.path import join as opj, pardir, dirname
+
 from pprint import pprint
 
 from niceman.retrace.packagemanagers import identify_packages
-
+from niceman.tests.utils import skip_if
 
 def test_identify_packages():
     files = ["/usr/share/doc/xterm/copyright",
@@ -24,3 +28,13 @@ def test_identify_packages():
     pprint(origins)
     pprint(packages)
     assert True
+
+
+@skip_if(not lexists(opj(dirname(__file__), pardir, pardir, pardir, '.git')))
+def test_identify_myself():
+    packages, origins, files = identify_packages([__file__, '/nonexisting-for-sure'])
+    assert len(packages) == 1
+    assert packages[0]['type'] == 'git'
+    assert packages[0]['files'] == [__file__]
+
+    assert files == ['/nonexisting-for-sure']

--- a/niceman/retrace/tests/test_packagemanagers.py
+++ b/niceman/retrace/tests/test_packagemanagers.py
@@ -70,7 +70,7 @@ def test_find_release_file():
 
 
 @with_tempfile(mkdir=True)
-def test_detached_git(repo):
+def test_detached_git(repo=None):
     import os
     from niceman.cmd import Runner
     env = os.environ.copy()

--- a/niceman/retrace/vcs.py
+++ b/niceman/retrace/vcs.py
@@ -146,7 +146,7 @@ class SVNRepo(GitSVNRepo):
                     'svn info',
                     expect_fail=True)
             except CommandError as exc:
-                if "Please see the 'svn upgrade' command" in exc.message:
+                if "Please see the 'svn upgrade' command" in str(exc):
                     lgr.warning(
                         "SVN at %s is outdated, needs 'svn upgrade'",
                         dirpath)

--- a/niceman/retrace/vcs.py
+++ b/niceman/retrace/vcs.py
@@ -1,0 +1,281 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil; coding: utf-8 -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the niceman package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Classes to identify package sources for files"""
+
+from __future__ import unicode_literals
+
+import os
+
+from os.path import dirname, isdir, isabs
+from os.path import exists, lexists
+from os.path import join as opj
+
+from logging import getLogger
+from six import viewvalues
+
+from niceman.dochelpers import exc_str
+
+try:
+    import apt
+    import apt.utils as apt_utils
+    import apt_pkg
+    cache = apt.Cache()
+except ImportError:
+    apt = None
+    apt_utils = None
+    apt_pkg = None
+    cache = None
+
+from niceman.cmd import Runner
+from niceman.cmd import CommandError
+
+lgr = getLogger('niceman.api.retrace')
+
+from .packagemanagers import PackageManager
+
+
+class VCSRepo(object):
+    """Base VCS repo class"""
+
+    def __init__(self, path):
+        """Representation for a repository
+
+        Parameters
+        ----------
+        path: str
+           Path to the top of the repository
+
+        """
+        self.path = path
+
+
+class GitSVNRepo(VCSRepo):
+    """apparently for now the way to figure out files is similar
+
+    Might later become a mix-in class for any VCS having such "feature" as
+    listing files for a repo
+    """
+
+    _ls_files_command = None  # just need to define in subclass
+
+    def __init__(self, path):
+        """Representation for Git or SVN repository
+
+        Parameters
+        ----------
+        path: str
+           Path to the top of the repository
+
+        """
+        super(GitSVNRepo, self).__init__(self, path)
+        self._files = None
+
+    @property
+    def files(self):
+        if self._files is None:
+            out, err = Runner(env={'LC_ALL': 'C'}, cwd=self.path)(
+                self._ls_files_command
+            )
+            assert not err
+            self._files = set(filter(None, out.split('\n')))
+        return self._files
+
+    def is_mine(self, path):
+        # does this repository have this directory under its control?
+        # NOTE:
+        #  this is an interesting case -- don't we want to still track "possible"
+        #  artifacts produced from the repos?  e.g. ./build subdirectory
+        #  But for that we would need to ask twice -- first a full sweep across
+        #  all Resolvers making it all strict checks, and then again through
+        #  those which could potentially claim it to belong to the repo?
+        #  For now just a strict check, and we would want to request all files
+        #  which repo knows about
+        rpath = path[len(self.path)+1:]
+        return rpath in self.files
+
+    @classmethod
+    def get_at_dirpath(cls, dirpath):
+        raise NotImplementedError
+
+
+class SVNRepo(GitSVNRepo):
+    _ls_files_command = 'sqlite3 -batch .svn/wc.db ".headers off" "select local_relpath from nodes_base"'
+
+    @classmethod
+    def get_at_dirpath(cls, dirpath):
+        if not exists(opj(dirpath, '.svn')):
+            return None
+        # for now we treat each directory under SVN independently
+        # pros:
+        #   - could provide us 'minimal' set of checkouts to do, since it might be
+        #      quite expensive to checkout the entire tree if it was not used
+        #      besides few leaves
+        lgr.debug("Detected SVN repository at %s", dirpath)
+        return cls(dirpath)
+
+
+class GitRepo(GitSVNRepo):
+    _ls_files_command = 'git ls-files'
+
+    @classmethod
+    def get_at_dirpath(cls, dirpath):
+        try:
+            out, err = Runner(cwd=dirpath).run(
+                'git rev-parse --show-toplevel',
+                expect_fail=True)
+        except CommandError as exc:
+            lgr.debug(
+                "Probably %s is not under git repo path: %s",
+                dirpath, exc_str(exc)
+            )
+            return None
+        topdir = out.rstrip('\n')
+        lgr.debug("Detected Git repository at %s for %s", topdir, dirpath)
+        return cls(topdir)
+
+
+
+class VCSManager(PackageManager):
+    """Resolve files into Git repositories they are contained with
+
+    TODO: generalize to other common VCS (svn, hg, bzr) which should win one
+    over the other depending on the path, e.g. for path
+
+    Devel notes:
+    - Whenever we allow for some "hypothetical" ownership, /a/b/c/d/f with
+      git at /a/b and hg at /a/b/c/ it must be hg repo which contains it.
+      But may be we wouldn't need that and should just grab all the repositories
+      for which we have strict membership hits, and then all possible which sit
+      above files which were not found belonging to any -- that is where we
+      could go with the most nested one and include it as well, although without
+      assigning any file specifically to it
+    - CVS and svn might be the first ones to consider since they have corresponding
+      .svn and CVS at every level in their hierarchy so easier to catch
+
+    Assumptions:
+    - VCS operate at the "directories" level, i.e. the file /a/b/c can't be contained
+      in one VCS whenever /a/b/d file in another
+    """
+
+    REGISTERED_VCS = (SVNRepo, GitRepo)
+
+    def __init__(self, *args, **kwargs):
+        super(VCSManager, self).__init__(*args, **kwargs)
+        # dictionary to contain per each inspected/known directory a VCS
+        # instance it belongs to
+        self._known_repos = {}
+
+
+    def _create_package(self, pkgname):
+        raise NotImplementedError
+
+
+    def _get_packages_for_files(self, files):
+        file_to_package_dict = {}
+
+        return file_to_package_dict
+
+    def resolve_file(self, path):
+        # very naive just to get a ball rolling
+        if not isabs(path):
+            raise ValueError("ATM operating on full paths, got %s" % path)
+        dirpath = path if isdir(path) else dirname(path)
+
+        # quick check first
+        if dirpath in self._known_repos:
+            return self._known_repos[dirpath]
+
+        # it could still be a subdirectory known to the repository known above it
+        for repo in self._known_repos.values():
+            # XXX this design is nohow accounts for some fancy cases where
+            # someone could use GIT_TREE and other trickery to have out of the
+            # directory checkout.  May be some time we would get there but
+            # for now
+            # should be ok
+
+            # could be less efficient than some str manipulations but ok for now
+            if os.path.commonprefix(repo.path, path) != repo.path:
+                continue
+
+            # could be less efficient than some str manipulations but ok for now
+            # since we rely on a strict check (must be registered within the repo)
+            if repo.is_mine(path):
+                return repo
+
+        # ok -- if it is not among known repos, we need to 'sniff' around
+        # if there is a repository at that path
+        for VCS in self.REGISTERED_VCS:
+            vcs = VCS.get_at_dirpath(dirpath)
+            if vcs:
+                # so there is one nearby -- record it
+                self._known_repos[vcs.path] = vcs
+                # but it might still not to know about the file
+                if vcs.is_mine(path):
+                    return vcs
+                # if not -- just keep going to the next candidate repository
+        return None
+
+
+    # actually we might better just overload the entire search
+    def search_for_files(self, files):
+        """Identifies the VCS repos for a given collection of files
+
+
+        Parameters
+        ----------
+        files : iterable
+            Container (e.g. list or set) of file paths
+
+        Return
+        ------
+        (found_packages, unknown_files)
+            - found_packages is an array of dicts that holds information about
+              the found packages. Package dicts need at least "name" and
+              "files" (that contains an array of related files)
+            - unknown_files is a list of files that were not found in
+              a package
+        """
+        unknown_files = set()
+        found_packages = {}  # TODO: rename?
+        nb_pkg_files = 0
+
+        file_to_package_dict
+        for f in files:
+            # Stores the file
+            if f not in file_to_package_dict:
+                unknown_files.add(f)
+            else:
+                pkgname = file_to_package_dict[f]
+                if pkgname in found_packages:
+                    found_packages[pkgname]["files"].append(f)
+                    nb_pkg_files += 1
+                else:
+                    pkg = self._create_package(pkgname)
+                    if pkg:
+                        found_packages[pkgname] = pkg
+                        pkg["files"].append(f)
+                        nb_pkg_files += 1
+                    else:
+                        unknown_files.add(f)
+
+        # here we need also to get "leaf" vcs possibly sitting on top of
+        # unknown files since later those might be used to hint to produced
+        # artifacts.  They will have no files associated with them
+        # TODO
+
+        lgr.info("%d packages with %d files, and %d other files",
+                 len(found_packages),
+                 nb_pkg_files,
+                 len(unknown_files))
+
+        return list(viewvalues(found_packages)), unknown_files
+
+    def identify_package_origins(self, *args, **kwargs):
+        # no origins for any VCS AFAIK
+        return None

--- a/niceman/utils.py
+++ b/niceman/utils.py
@@ -427,6 +427,10 @@ def assure_dict_from_str(s, **kwargs):
         out[k] = v
     return out
 
+def only_with_values(d):
+    """Given a dictionary, return the one only with entries which had non-null values"""
+    # to maintain OrderedDict do explicit d.__class__
+    return d.__class__((k, v) for k,v in d.items() if v)
 
 def unique(seq, key=None):
     """Given a sequence return a list only with unique elements while maintaining order


### PR DESCRIPTION
Sits on top of @rbuccigrossi #58 

TODOs
- [x] make it work at all
- [x] basic testing
- [x] sources (remotes) for git repos
- [x] record current branch as well where applicable
- [ ] DataLad datasets support (those are just 'git' repos, but in direct mode might not look as such ;) )
- [ ] more tests!  currently barely covered

It also
- [x] refactors retrace a bit so you can now just specify bunch of files on your filesystem to be 'traced' in addition to the spec -- really handy for interactive "investigation"

Future TODOs is to support
- [ ] hg 
- [ ] CVS
- [ ] bzr
and refactor code accordingly

Also possibly
- [ ] extend to annotate changed files (might we want even to store diffs???)

## Questions

- For VCS types -- should we may be list only relative path names in files? then full paths should be easily reconstructable with a simple rule `if not isabs(path): fullpath = opj(pkg['path'], path)`?
- For full paths under '$HOME' -- I wonder if we should do analysis right away and convert them to use that (e.g. to make them '$HOME/blah' instead of '/home/yoh/blah' in my case)... and then record 'run' session and associate with tracking one which would contain value for HOME?

Sample output:
```shell
(git)hopa:~/proj/repronim/niceman[nf-git-trace]
$> niceman --dbg retrace ~/proj/repronim/niceman/README.md /home/yoh/deb/debs/imagezoom-ru-svn/trunk.upgraded/debian/changelog /usr/bin/fail2ban-client                                                                         2017-02-27 20:23:16,003 [INFO   ] DpkgManager: 1 packages with 1 files, and 2 other files 
2017-02-27 20:23:16,238 [INFO   ] VCSManager: 2 packages with 2 files, and 0 other files 
# NICEMAN Environment Configuration File
# This file was created by NICEMAN 0.0.1 on 2017-02-27 20:23:16.239261

# Package Origins 

origins:
- {name: apt_Debian_testing_main_0, type: apt, origin: Debian, label: Debian, component: main,
  archive: testing, site: http.debian.net}
- {name: apt_Debian_unstable_main_0, type: apt, origin: Debian, label: Debian, component: main,
  archive: unstable, site: http.debian.net}
- {name: apt_NeuroDebian_sid_main_0, type: apt, origin: NeuroDebian, archive: sid,
  date: '2017-02-22 16:10:55+00:00', component: main, site: neuro.debian.net, label: NeuroDebian}
- {name: apt__now_now_0, type: apt, origin: '', label: '', component: now, archive: now,
  site: ''}

# Packages 

packages:
- name: fail2ban
  type: dpkg
  version: 0.9.6-1
  candidate: 0.9.6-1
  size: 287264
  architecture: all
  md5: 1dd9650399499fc85f5ca033cab61d49
  sha1: ''
  sha256: 0f7c15500bb57af1a8881b013fcf720d611bfa669ba5f2d8cfc4003ce1bef1af
  source_name: fail2ban
  source_version: 0.9.6-1
  files: [/usr/bin/fail2ban-client]
  install_date: '2016-12-09 20:51:41.355989+00:00'
  version_table:
  - origins: [apt_Debian_testing_main_0, apt_Debian_testing_main_0, apt_Debian_unstable_main_0,
      apt_Debian_unstable_main_0, apt__now_now_0]
    version: 0.9.6-1
  - origins: [apt_NeuroDebian_sid_main_0, apt_NeuroDebian_sid_main_0]
    version: 0.9.6-1~nd+1
- path: /home/yoh/deb/debs/imagezoom-ru-svn/trunk.upgraded/debian
  type: svn
  revision: '1270'
  url: svn+ssh://washoe.rutgers.edu/home/yoh/.svn/debs/imagezoom/trunk/debian
  root_url: svn+ssh://washoe.rutgers.edu/home/yoh/.svn
  relative_url: ^/debs/imagezoom/trunk/debian
  uuid: 82381867-18eb-0310-98a2-9474e637aba2
  files: [/home/yoh/deb/debs/imagezoom-ru-svn/trunk.upgraded/debian/changelog]
- path: /home/yoh/proj/repronim/niceman
  type: git
  hexsha: ba729228fe3cf30f50745bf2a828befb22676688
  branch: nf-git-trace
  tracked_remote: gh-yarikoptic
  remotes:
    gh-chaselgrove: {url: 'git://github.com/chaselgrove/ReproNim'}
    gh-mjtravers: {url: 'https://github.com/mjtravers/ReproNim'}
    gh-rbuccigrossi: {url: 'git://github.com/rbuccigrossi/ReproNim'}
    gh-yarikoptic: {url: 'git@github.com:yarikoptic/ReproNim'}
    origin: {url: 'git@github.com:ReproNim/niceman'}
  files: [/home/yoh/proj/repronim/niceman/README.md]

# Other ReproZip keys (not used by NICEMAN) 

{}
```