### PR TITLE
BF: Use ArchiveURI to identify local repositories

### DIFF
--- a/niceman/retrace/packagemanagers.py
+++ b/niceman/retrace/packagemanagers.py
@@ -257,6 +257,7 @@ class DpkgManager(PackageManager):
                 # Pull origin information from package file
                 origin = {"component": pf.component,
                           "archive": pf.archive,
+                          "architecture": pf.architecture,
                           "origin": pf.origin,
                           "label": pf.label,
                           "site": pf.site}

--- a/niceman/retrace/packagemanagers.py
+++ b/niceman/retrace/packagemanagers.py
@@ -293,6 +293,7 @@ class DpkgManager(PackageManager):
             for ending in ['_InRelease', '_Release']:
                 if os.path.exists(rfprefix + ending):
                     rfile = rfprefix + ending
+                    break
         return rfile
 
     def _find_release_date(self, rfile):

--- a/niceman/retrace/tests/test_packagemanagers.py
+++ b/niceman/retrace/tests/test_packagemanagers.py
@@ -13,6 +13,7 @@ from niceman.retrace.packagemanagers import identify_packages
 
 def test_identify_packages():
     files = ["/usr/share/doc/xterm/copyright",
+             "/usr/games/alienblaster",
              "/usr/share/icons/hicolor/48x48/apps/xterm-color.png",
              "/usr/share/doc/zlib1g/copyright",
              "/usr/bin/vim.basic",


### PR DESCRIPTION
To address #59 , I use the lower level apt_pkg python library to pull the archive_uri associated with an origin. This allows me to more accurately create the release file name, and pull the release file for local repositories.

To test, I created a repository with the alienblaster package:

```
mkdir /my
mkdir /my/repo
cd /my/repo
wget http://mirrors.kernel.org/ubuntu/pool/universe/a/alienblaster/alienblaster_1.1.0-9_amd64.deb
dpkg-scanpackages . >| Packages
apt-ftparchive release . >| Release
echo 'deb file:///my/repo ./' > /etc/apt/sources.list.d/local.list
apt-get update
apt-get install alienblaster
```

The resulting origin entry is:

```
- {name: apt____0, type: apt, component: '', label: '', site: '', archive_uri: 'file:///my/repo/',
  archive: '', origin: '', date: '2017-02-21 02:42:30+00:00'}
```

Closes #59 