### PR TITLE
BF: Fixing search technique for the Release File Name

### DIFF
--- a/niceman/retrace/packagemanagers.py
+++ b/niceman/retrace/packagemanagers.py
@@ -288,14 +288,13 @@ class DpkgManager(PackageManager):
         # is at an underscore, so split the package filename
         # at underscores and test for the release file:
         rfprefix = package_filename
-        rfile = None
         while "_" in rfprefix:
             rfprefix = rfprefix.rsplit("_", 1)[0]
             for ending in ['_InRelease', '_Release']:
                 if os.path.exists(rfprefix + ending):
-                    rfile = rfprefix + ending
-                    break
-        return rfile
+                    return rfprefix + ending
+        # No file found
+        return None
 
     def _find_release_date(self, rfile):
         # Extract and format the date from the release file


### PR DESCRIPTION
I adjusted the inner loop of _find_release_file so that it returns the Release file that matches the largest prefix of the source package filename.  The way it was before, if there was a smaller prefix that matched a Release file name, then it would use that instead.  For example: us.archive.ubuntu.com_ubuntu_dists_xenial-updates_main_binary-amd64_Packages could potentially match both us.archive.ubuntu.com_ubuntu_dists_xenial-updates_InRelease and us.archive.ubuntu.com_ubuntu_dists_InRelease (if they both existed).  But we want the longer one to be returned, not the shorter one.
