### PR TITLE
Initial dockerpty setup

### DIFF
--- a/docs/source/cmdline.rst
+++ b/docs/source/cmdline.rst
@@ -27,6 +27,7 @@ Environments operations
    generated/man/niceman-delete
    generated/man/niceman-start
    generated/man/niceman-stop
+   generated/man/niceman-login
 
 Miscellaneous commands
 ======================

--- a/niceman/interface/__init__.py
+++ b/niceman/interface/__init__.py
@@ -26,6 +26,7 @@ _group_dataset = (
         ('niceman.interface.delete', 'Delete'),
         ('niceman.interface.start', 'Start'),
         ('niceman.interface.stop', 'Stop'),
+        ('niceman.interface.login', 'Login'),
         # ('niceman.distribution.run', 'Run'),
     ])
 

--- a/niceman/interface/login.py
+++ b/niceman/interface/login.py
@@ -20,16 +20,16 @@ from ..support.constraints import EnsureStr
 from ..resource import Resource
 
 from logging import getLogger
-lgr = getLogger('niceman.api.start')
+lgr = getLogger('niceman.api.delete')
 
 
-class Stop(Interface):
-    """Stop a computation environment
+class Login(Interface):
+    """Log into a computation environment
 
     Examples
     --------
 
-      $ niceman stop --resource=my-resource --config=niceman.cfg
+      $ niceman login --resource=my-resource --config=niceman.cfg
 
     """
 
@@ -81,6 +81,4 @@ class Stop(Interface):
         if not env_resource.id:
             raise ValueError("No resource found given the info %s" % str(resource_info))
 
-        env_resource.stop()
-
-        lgr.info("Stopped the environment %s", resource)
+        env_resource.login()

--- a/niceman/interface/login.py
+++ b/niceman/interface/login.py
@@ -20,7 +20,7 @@ from ..support.constraints import EnsureStr
 from ..resource import Resource
 
 from logging import getLogger
-lgr = getLogger('niceman.api.delete')
+lgr = getLogger('niceman.api.login')
 
 
 class Login(Interface):
@@ -74,7 +74,7 @@ class Login(Interface):
         #       why should we???
         resource_info, inventory = get_resource_info(config, resource, resource_id)
 
-        # Delete resource environment
+        # Connect to resource environment
         env_resource = Resource.factory(resource_info)
         env_resource.connect()
 

--- a/niceman/interface/start.py
+++ b/niceman/interface/start.py
@@ -20,7 +20,7 @@ from ..support.constraints import EnsureStr
 from ..resource import Resource
 
 from logging import getLogger
-lgr = getLogger('niceman.api.delete')
+lgr = getLogger('niceman.api.start')
 
 
 class Start(Interface):

--- a/niceman/interface/stop.py
+++ b/niceman/interface/stop.py
@@ -20,7 +20,7 @@ from ..support.constraints import EnsureStr
 from ..resource import Resource
 
 from logging import getLogger
-lgr = getLogger('niceman.api.start')
+lgr = getLogger('niceman.api.stop')
 
 
 class Stop(Interface):

--- a/niceman/interface/tests/test_create.py
+++ b/niceman/interface/tests/test_create.py
@@ -32,7 +32,7 @@ def test_create_interface(niceman_cfg_path):
                 '{ "status" : "status 1", "progress" : "progress 1" }',
                 '{ "status" : "status 2", "progress" : "progress 2" }'
             ],
-            create_container=lambda name, image, stdin_open, detach: {
+            create_container=lambda name, image, stdin_open, tty, command: {
                 'Id': '18b31b30e3a5'
             }
         )

--- a/niceman/interface/tests/test_login.py
+++ b/niceman/interface/tests/test_login.py
@@ -1,0 +1,62 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the niceman package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+
+from niceman.cmdline.main import main
+
+import logging
+from mock import patch, call, MagicMock
+
+from niceman.utils import swallow_logs
+from niceman.tests.utils import assert_in
+
+
+def test_login_interface(niceman_cfg_path):
+    """
+    Test logging into an environment
+    """
+
+    with patch('docker.Client') as client, \
+        patch('niceman.interface.base.get_resource_inventory') as get_inventory, \
+        patch('dockerpty.start'), \
+        swallow_logs(new_level=logging.DEBUG) as log:
+
+        client.return_value = MagicMock(
+            containers=lambda all: [
+                {
+                    'Id': '18b31b30e3a5',
+                    'Names': ['/my-test-resource'],
+                    'State': 'running'
+                }
+            ],
+        )
+
+        get_inventory.return_value = {
+            "my-test-resource": {
+                "status": "running",
+                "engine_url": "tcp://127.0.0.1:2375",
+                "type": "docker-container",
+                "name": "my-test-resource",
+                "id": "18b31b30e3a5"
+            }
+        }
+
+        args = ['login',
+                '--resource', 'my-test-resource',
+                '--config', niceman_cfg_path
+        ]
+        main(args)
+
+        assert client.call_count == 1
+
+        calls = [
+            call(base_url='tcp://127.0.0.1:2375')
+        ]
+        client.assert_has_calls(calls, any_order=True)
+
+        assert_in("Opening TTY connection to docker container.", log.lines)

--- a/niceman/resource/docker_container.py
+++ b/niceman/resource/docker_container.py
@@ -149,4 +149,5 @@ class DockerContainer(Resource):
         """
         Log into a container and get the command line
         """
+        lgr.debug("Opening TTY connection to docker container.")
         dockerpty.start(self._client, self._container, logs=0)

--- a/niceman/resource/docker_container.py
+++ b/niceman/resource/docker_container.py
@@ -10,6 +10,7 @@
 
 import attr
 import docker
+import dockerpty
 import json
 from ..support.exceptions import CommandError, ResourceError
 from .base import Resource
@@ -84,7 +85,10 @@ class DockerContainer(Resource):
             name=self.name,
             image=self.base_image_id,
             stdin_open=True,
-            detach=True)
+            # detach=True,
+            tty=True,
+            command='/bin/sh',
+        )
         self.id = self._container.get('Id')
         self.status = 'running'
         self._client.start(container=self.id)
@@ -141,3 +145,11 @@ class DockerContainer(Resource):
         """
         if self._container:
             self._client.stop(container=self._container.get('Id'))
+
+    def login(self):
+        """
+        Log into a container and get the command line
+        """
+
+        # press C-p C-q to close but keep container running
+        dockerpty.start(self._client, self._container)

--- a/niceman/resource/docker_container.py
+++ b/niceman/resource/docker_container.py
@@ -85,9 +85,8 @@ class DockerContainer(Resource):
             name=self.name,
             image=self.base_image_id,
             stdin_open=True,
-            # detach=True,
             tty=True,
-            command='/bin/sh',
+            command='/bin/bash',
         )
         self.id = self._container.get('Id')
         self.status = 'running'
@@ -150,6 +149,4 @@ class DockerContainer(Resource):
         """
         Log into a container and get the command line
         """
-
-        # press C-p C-q to close but keep container running
-        dockerpty.start(self._client, self._container)
+        dockerpty.start(self._client, self._container, logs=0)

--- a/niceman/resource/tests/test_docker_container.py
+++ b/niceman/resource/tests/test_docker_container.py
@@ -42,7 +42,7 @@ def test_dockercontainer_class():
                 '{ "status" : "status 1", "progress" : "progress 1" }',
                 '{ "status" : "status 2", "progress" : "progress 2" }'
             ],
-            create_container=lambda name, image, stdin_open, tty: {
+            create_container=lambda name, image, stdin_open, tty, command: {
                 'Id': '18b31b30e3a5'
             }
         )

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,8 @@ requires = {
         'chardet',  # python-debian misses dependency on it
     ],
     'docker': [
-        'docker-py',
+        'docker-py>=0.3.2',
+        'dockerpty',
     ],
     'aws': [
         'boto3',


### PR DESCRIPTION
This is not an actual pull request yet. Just sharing code.

The tty terminal replays all the commands run from a previous session when the container is restarted. Still figuring that one out.

To login to a docker container, first create it and then login (like so):

niceman create -r my-container -t docker-container
niceman login -r my-container

