### PR TITLE
BF: Fix for #83 to support Unicode filenames and package data

### DIFF
--- a/niceman/retrace/packagemanagers.py
+++ b/niceman/retrace/packagemanagers.py
@@ -234,15 +234,13 @@ class DpkgManager(PackageManager):
                     expect_stderr=True, expect_fail=True
                 )
             except CommandError as exc:
-                if 'no path found matching pattern' in exc.stderr:
+                stderr = utils.safe_decode(exc.stderr, "utf-8")
+                if 'no path found matching pattern' in stderr:
                     out = exc.stdout  # One file not found, so continue
                 else:
                     raise  # some other fault -- handle it above
             # Decode output for Python 2
-            try:
-                out = out.decode()
-            except AttributeError:
-                pass
+            out = utils.safe_decode(out, "utf-8")
 
             # Now go through the output and assign packages to files
             for outline in out.splitlines():

--- a/niceman/retrace/packagemanagers.py
+++ b/niceman/retrace/packagemanagers.py
@@ -234,13 +234,13 @@ class DpkgManager(PackageManager):
                     expect_stderr=True, expect_fail=True
                 )
             except CommandError as exc:
-                stderr = utils.safe_decode(exc.stderr, "utf-8")
+                stderr = utils.to_unicode(exc.stderr, "utf-8")
                 if 'no path found matching pattern' in stderr:
                     out = exc.stdout  # One file not found, so continue
                 else:
                     raise  # some other fault -- handle it above
             # Decode output for Python 2
-            out = utils.safe_decode(out, "utf-8")
+            out = utils.to_unicode(out, "utf-8")
 
             # Now go through the output and assign packages to files
             for outline in out.splitlines():

--- a/niceman/retrace/rpzutil.py
+++ b/niceman/retrace/rpzutil.py
@@ -12,6 +12,7 @@
 from __future__ import unicode_literals
 
 import collections
+
 import datetime
 import niceman
 import niceman.utils as utils
@@ -73,6 +74,9 @@ def identify_packages(config=None, paths=None):
     else:
         config = {}
 
+    # Convert paths to unicode
+    paths = list(map(utils.to_unicode, paths))
+
     # TODO: RF so that only the above portion is reprozip specific.
     # If we are to reuse their layout largely -- the rest should stay as is
     (packages, origins, unidentified_files) = \
@@ -131,10 +135,11 @@ def write_config(output, config):
     c = "\n# Non-Packaged Files \n\n"
     write_config_key(output, envconfig, "other_files", c)
 
-    output.write("\n# Other ReproZip keys (not used by NICEMAN) \n\n")
-    output.write(utils.unicode(yaml.safe_dump(envconfig,
-                                              encoding="utf-8",
-                                              allow_unicode=True)))
+    if (envconfig):
+        output.write("\n# Other ReproZip keys (not used by NICEMAN) \n\n")
+        utils.safe_write(output, yaml.safe_dump(envconfig,
+                                                encoding="utf-8",
+                                                allow_unicode=True))
 
 
 def write_config_key(os, envconfig, key, intro_comment=""):
@@ -159,10 +164,10 @@ def write_config_key(os, envconfig, key, intro_comment=""):
         mini_config = dict()
         mini_config[key] = envconfig[key]
         del envconfig[key]
-        os.write(intro_comment)
-        os.write(utils.unicode(yaml.safe_dump(mini_config,
-                                              encoding="utf-8",
-                                              allow_unicode=True)))
+        utils.safe_write(os, intro_comment)
+        utils.safe_write(os, yaml.safe_dump(mini_config,
+                                            encoding="utf-8",
+                                            allow_unicode=True))
 
 
 def get_system_files(config):

--- a/niceman/retrace/tests/test_packagemanagers.py
+++ b/niceman/retrace/tests/test_packagemanagers.py
@@ -1,5 +1,6 @@
 # emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
-# ex: set sts=4 ts=4 sw=4 noet:
+# -*- coding: utf-8 -*-
+#  ex: set sts=4 ts=4 sw=4 noet:
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 #
 #   See COPYING file distributed along with the niceman package for the
@@ -34,6 +35,17 @@ def test_identify_packages():
              "/usr/share/bug/vim/script",
              "/home/butch"]
     # Simple sanity check that the pipeline works
+    packages, origins, files = identify_packages(files)
+    pprint(files)
+    pprint(origins)
+    pprint(packages)
+    assert True
+
+
+@skip_if(not apt)
+def test_utf8_file():
+    files = [u"/usr/share/ca-certificates/mozilla/TÜBİTAK_UEKAE_Kök_Sertifika_Hizmet_Sağlayıcısı_-_Sürüm_3.crt"]
+    # Simple sanity check that the pipeline works with utf-8
     packages, origins, files = identify_packages(files)
     pprint(files)
     pprint(origins)

--- a/niceman/retrace/tests/test_packagemanagers.py
+++ b/niceman/retrace/tests/test_packagemanagers.py
@@ -1,6 +1,5 @@
-# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
-# -*- coding: utf-8 -*-
-#  ex: set sts=4 ts=4 sw=4 noet:
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil; coding: utf-8 -*-
+# ex: set sts=4 ts=4 sw=4 noet:
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 #
 #   See COPYING file distributed along with the niceman package for the
@@ -44,13 +43,19 @@ def test_identify_packages():
 
 @skip_if(not apt)
 def test_utf8_file():
-    files = [u"/usr/share/ca-certificates/mozilla/TÜBİTAK_UEKAE_Kök_Sertifika_Hizmet_Sağlayıcısı_-_Sürüm_3.crt"]
+    files = [u"/usr/share/ca-certificates/mozilla/"
+             u"TÜBİTAK_UEKAE_Kök_Sertifika_Hizmet_Sağlayıcısı_-_Sürüm_3.crt"]
     # Simple sanity check that the pipeline works with utf-8
-    packages, origins, files = identify_packages(files)
-    pprint(files)
+    packages, origins, files_left = identify_packages(files)
+    # Print for manual debugging
+    pprint(files_left)
     pprint(origins)
     pprint(packages)
-    assert True
+    # If the file exists, it should be in ca-certificates
+    if os.path.isfile(files[0]):
+        assert packages[0]["name"] == "ca-certificates"
+    else:  # Otherwise just make sure we didn't throw an exception
+        assert True
 
 
 @skip_if(not apt)

--- a/niceman/tests/test_utils.py
+++ b/niceman/tests/test_utils.py
@@ -45,7 +45,8 @@ from ..utils import generate_unique_name
 
 from nose.tools import ok_, eq_, assert_false, assert_equal, assert_true
 
-from .utils import with_tempfile, assert_in, with_tree
+from .utils import with_tempfile, assert_in, with_tree, to_binarystring, \
+    is_unicode, is_binarystring
 from .utils import SkipTest
 from .utils import assert_cwd_unchanged, skip_if_on_windows
 from .utils import assure_dict_from_str, assure_list_from_str
@@ -405,16 +406,14 @@ def test_path_():
         assert(_path_(p) is p)  # nothing is done to it whatsoever
 
 
-def test_unicode():
-    if PY3:
-        s = b"mytest"
-        s2 = "mytest"
-        assert(to_unicode(s) == s2)
-        assert(to_unicode(s2) == s2)
-    else:
-        s = "mytest"
-        s2 = to_unicode(s)
-        assert(s2 == __builtin__.unicode(s))
+def test_unicode_and_binary_conversion():
+    s = "Test String"
+    s_unicode = to_unicode(s)
+    s_binary = to_binarystring(s)
+    assert (is_unicode(s_unicode))
+    assert (not(is_binarystring(s_unicode)))
+    assert (is_binarystring(s_binary))
+    assert (not(is_unicode(s_binary)))
 
 
 def test_generate_unique_set():

--- a/niceman/tests/test_utils.py
+++ b/niceman/tests/test_utils.py
@@ -40,7 +40,7 @@ from ..utils import get_func_kwargs_doc
 from ..utils import make_tempfile
 from ..utils import on_windows
 from ..utils import _path_
-from ..utils import unicode
+from ..utils import to_unicode
 from ..utils import generate_unique_name
 
 from nose.tools import ok_, eq_, assert_false, assert_equal, assert_true
@@ -409,11 +409,11 @@ def test_unicode():
     if PY3:
         s = b"mytest"
         s2 = "mytest"
-        assert(unicode(s) == s2)
-        assert(unicode(s2) == s2)
+        assert(to_unicode(s) == s2)
+        assert(to_unicode(s2) == s2)
     else:
         s = "mytest"
-        s2 = unicode(s)
+        s2 = to_unicode(s)
         assert(s2 == __builtin__.unicode(s))
 
 

--- a/niceman/utils.py
+++ b/niceman/utils.py
@@ -892,49 +892,36 @@ def _path_(p):
 
 def is_unicode(s):
     """Return true if an object is unicode"""
-    return  (six.PY3 and isinstance(s, str)) or \
-            (six.PY2 and isinstance(s, unicode))
+    return isinstance(s, six.text_type)
+
+
+def is_binarystring(s):
+    """Return true if an object is a binary string (not unicode)"""
+    return isinstance(s, six.binary_type)
 
 
 def to_unicode(s, encoding="utf-8"):
-    """Given a str type, convert to unicode"""
-    # If unicode, just return it
+    """Converts any type string to unicode"""
     if is_unicode(s):
         return s
-    try:
-        if six.PY3:
-            return str(s, encoding)
-        else:
-            return __builtin__.unicode(s, encoding)
-    except TypeError:
-        raise TypeError("Incorrect type for to_unicode()")
-
-
-def safe_decode(s, encoding="utf-8"):
-    """safe_decode attempts to call "decode" with the given encoding."""
-    try:
-        return s.decode(encoding=encoding)
-    except AttributeError:
-        return s
-
-
-def safe_encode(s, encoding="utf-8"):
-    """safe_encode attempts to call "encode" with the given encoding."""
-    try:
-        return s.encode(encoding=encoding)
-    except AttributeError:
-        return s
-
-
-def safe_write(os, s, encoding="utf-8"):
-    """safe_write safely writes different string types to an output stream"""
-    if PY3:
-        os.write(to_unicode(s))
     else:
-        try: # For PY2 try str first, then unicode
-            os.write(safe_encode(to_unicode(s, encoding), encoding))
-        except TypeError:
-            os.write(to_unicode(s, encoding))
+        return s.decode(encoding=encoding)
+
+
+def to_binarystring(s, encoding="utf-8"):
+    """Converts any type string to binarystring"""
+    if is_binarystring(s):
+        return s
+    else:
+        return s.encode(encoding=encoding)
+
+
+def safe_write(ostream, s, encoding="utf-8"):
+    """Safely write different string types to an output stream"""
+    try:  # Try unicode, and upon failure try binary_string
+        ostream.write(to_unicode(s, encoding))
+    except (TypeError, UnicodeEncodeError):
+        ostream.write(to_binarystring(s, encoding))
 
 
 def generate_unique_name(pattern, nameset):


### PR DESCRIPTION
I still want to add unit tests for a couple of utility functions I added (safe_decode, safe_encode, and safe_write).