### PR TITLE
BF(BK): moved installing of python-apt from source into a script to not mask failures to build it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # vim ft=yaml
-# travis-ci.org definition for DataLad build
+# travis-ci.org definition for NICEMAN build
 language: python
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,9 +51,7 @@ before_install:
 
 install:
   # all mess below to get an elderly python-apt installed on elderly precise within python env -- we must build it
-  - sudo apt-get build-dep python-apt
-  # Install python-apt version 0.9.3.5 for Python 2 and 3
-  - sudo apt-get install xz-utils; curl -O http://archive.ubuntu.com/ubuntu/pool/main/p/python-apt/python-apt_0.9.3.5.tar.xz; xz -d python-apt_0.9.3.5.tar.xz; pip install http://launchpad.net/python-distutils-extra/trunk/2.28/+download/python-distutils-extra-2.28.tar.gz python-apt_0.9.3.5.tar; rm python-apt_0.9.3.5.tar;
+  - sudo tools/ci/build_install_apt
   - cd ..; pip install -q codecov; cd -
   - pip install --upgrade pip
   # needed by html5lib

--- a/tools/ci/build_install_apt
+++ b/tools/ci/build_install_apt
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# to make sure  set -x wouldn't fail
+export PS4=+
+set -eux
+
+apt-get build-dep python-apt
+# Install python-apt version 0.9.3.5 for Python 2 and 3
+apt-get install xz-utils
+curl -O http://archive.ubuntu.com/ubuntu/pool/main/p/python-apt/python-apt_0.9.3.5.tar.xz
+xz -d python-apt_0.9.3.5.tar.xz
+pip install http://launchpad.net/python-distutils-extra/trunk/2.28/+download/python-distutils-extra-2.28.tar.gz python-apt_0.9.3.5.tar
+rm -f python-apt_0.9.3.5.tar

--- a/tools/ci/build_install_apt
+++ b/tools/ci/build_install_apt
@@ -4,10 +4,12 @@
 export PS4=+
 set -eux
 
+ver=1.1.0~beta1build1
+
 apt-get build-dep python-apt
 # Install python-apt version 0.9.3.5 for Python 2 and 3
 apt-get install xz-utils
-curl -O http://archive.ubuntu.com/ubuntu/pool/main/p/python-apt/python-apt_0.9.3.5.tar.xz
-xz -d python-apt_0.9.3.5.tar.xz
-pip install http://launchpad.net/python-distutils-extra/trunk/2.28/+download/python-distutils-extra-2.28.tar.gz python-apt_0.9.3.5.tar
-rm -f python-apt_0.9.3.5.tar
+curl -O http://archive.ubuntu.com/ubuntu/pool/main/p/python-apt/python-apt_$ver.tar.xz
+xz -d python-apt_$ver.tar.xz
+pip install http://launchpad.net/python-distutils-extra/trunk/2.28/+download/python-distutils-extra-2.28.tar.gz python-apt_$ver.tar
+rm -f python-apt_$ver.tar

--- a/tools/ci/build_install_apt
+++ b/tools/ci/build_install_apt
@@ -4,9 +4,10 @@
 export PS4=+
 set -eux
 
-ver=1.1.0~beta1build1
+ver=0.9.3.5
 
 apt-get build-dep python-apt
+apt-get install -y --allow-downgrades  libapt-pkg-dev=0.8.16~exp12ubuntu10.27
 # Install python-apt version 0.9.3.5 for Python 2 and 3
 apt-get install xz-utils
 curl -O http://archive.ubuntu.com/ubuntu/pool/main/p/python-apt/python-apt_$ver.tar.xz


### PR DESCRIPTION
By default in bash, exit status of the sequence of commands separated with ; is as of the last
command executed.  So if any of then fail before then, shell would still report "all is ok", unless

1. you set -e   setting for the session (then would fail as soon as any command fails)
2. join them with  & instead of ;

Since our line got too long already, I just moved that installation into a script which should fail
if any step fails (see set -eux at the top)

Detected when saw decreased coverage within https://github.com/ReproNim/niceman/pull/85 which should havenot changed coverage that drastically