### PR TITLE
ENH: Moved resource specific create parameters to resource Class.

### DIFF
--- a/niceman/interface/tests/test_create.py
+++ b/niceman/interface/tests/test_create.py
@@ -50,12 +50,13 @@ def test_create_interface(niceman_cfg_path):
         args = ['create',
                 '--resource', 'my-test-resource',
                 '--resource-type', 'docker-container',
-                '--config', niceman_cfg_path
+                '--config', niceman_cfg_path,
+                '--backend', 'engine_url=tcp://127.0.0.1:2376'
         ]
         main(args)
 
         calls = [
-            call(base_url='tcp://127.0.0.1:2375'),
+            call(base_url='tcp://127.0.0.1:2376'),
             call().start(container='18b31b30e3a5')
         ]
         client.assert_has_calls(calls, any_order=True)

--- a/niceman/resource/aws_ec2.py
+++ b/niceman/resource/aws_ec2.py
@@ -34,8 +34,8 @@ class AwsEc2(Resource):
     name = attr.ib()
 
     # Configurable options for each "instance"
-    access_key_id = attr.ib()
-    secret_access_key = attr.ib()
+    access_key_id = attr.ib(default=None)
+    secret_access_key = attr.ib(default=None)
     instance_type = attr.ib(default='t2.micro')  # EC2 instance type
     security_group = attr.ib(default='default')  # AWS security group
     region_name = attr.ib(default='us-east-1')  # AWS region
@@ -57,6 +57,26 @@ class AwsEc2(Resource):
     # Management properties
     _ec2_resource = attr.ib(default=None)
     _ec2_instance = attr.ib(default=None)
+
+    @staticmethod
+    def get_backend_properties():
+        """
+        Return the config properties specific to this resource type.
+
+        Returns
+        -------
+        dict : key = resource property, value = property description
+        """
+        return {
+            'access_key_id': 'AWS access key for remote access to your Amazon subscription.',
+            'secret_access_key': 'AWS secret access key for remote access to your Amazon subscription',
+            'instance_type': 'The type of Amazon EC2 instance to run. (e.g. t2.medium)',
+            'security_group': 'AWS security group to assign to the EC2 instance.',
+            'region_name': 'AWS availability zone to run the EC2 instance in. (e.g. us-east-1)',
+            'key_name': 'AWS subscription name of SSH key-pair registered.',
+            'key_filename': 'Path to SSH private key file matched with AWS key name parameter.',
+            'base_image_id': 'AWS image ID from which to create the running instance',
+        }
 
     def connect(self):
         """

--- a/niceman/resource/base.py
+++ b/niceman/resource/base.py
@@ -32,11 +32,10 @@ def attrib(*args, **kwargs):
     """
     Extend the attrs decorator to include a doc metadata element.
     """
-    doc = kwargs.get('doc')
+    doc = kwargs.pop('doc', None)
     metadata = kwargs.get('metadata', {})
     if doc:
         metadata['doc'] = doc
-        del kwargs['doc']
     if metadata:
         kwargs['metadata'] = metadata
     return attr.ib(*args, **kwargs)

--- a/niceman/resource/base.py
+++ b/niceman/resource/base.py
@@ -8,6 +8,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Classes to manage compute resources."""
 
+import attr
 from importlib import import_module
 import abc
 
@@ -27,12 +28,18 @@ from ..support.exceptions import ResourceError
 from ..support.exceptions import MissingConfigError, MissingConfigFileError
 from ..ui import ui
 
-# Enumerate the defined resource types available.
-VALID_RESOURCE_TYPES = [
-    'docker-container',
-    'aws-ec2',
-    'shell'
-]
+def attrib(*args, **kwargs):
+    """
+    Extend the attrs decorator to include a doc metadata element.
+    """
+    doc = kwargs.get('doc')
+    metadata = kwargs.get('metadata', {})
+    if doc:
+        metadata['doc'] = doc
+        del kwargs['doc']
+    if metadata:
+        kwargs['metadata'] = metadata
+    return attr.ib(*args, **kwargs)
 
 class ResourceManager(object):
     """
@@ -125,11 +132,14 @@ class ResourceManager(object):
         #       inventory
         # TODO:  if no name or id provided, then fail since this function
         #        is not created to return a list of resources for a given type ATM
+
+        vald_resource_types = [t.replace("_", "-") for t in ResourceManager._discover_types()]
+
         if name in inventory:
             # XXX so what is our convention here on SMTH-SMTH defining the type?
             config = dict(cm.items(inventory[name]['type'].split('-')[0]))
             config.update(inventory[name])
-        elif type_ and type_ in VALID_RESOURCE_TYPES:
+        elif type_ and type_ in vald_resource_types:
             config = dict(cm.items(type_.split('-')[0]))
         else:
             type_ = ui.question(
@@ -141,7 +151,7 @@ class ResourceManager(object):
                 default="docker-container"
             )
             config = {}
-            if type_ not in VALID_RESOURCE_TYPES:
+            if type_ not in vald_resource_types:
                 raise MissingConfigError(
                     "Resource type '{}' is not valid".format(type_))
 

--- a/niceman/resource/docker_container.py
+++ b/niceman/resource/docker_container.py
@@ -30,14 +30,28 @@ class DockerContainer(Resource):
     id = attr.ib(default=None)
     type = attr.ib(default='docker-container')
 
-    engine_url = attr.ib(default='unix:///var/run/docker.sock')
     base_image_id = attr.ib(default='ubuntu:latest')
+    engine_url = attr.ib(default='unix:///var/run/docker.sock')
 
     status = attr.ib(default=None)
 
     # Management properties
     _client = attr.ib(default=None)
     _container = attr.ib(default=None)
+
+    @staticmethod
+    def get_backend_properties():
+        """
+        Return the config properties specific to this resource type.
+
+        Returns
+        -------
+        dict : key = resource property, value = property
+        """
+        return {
+            'base_image_id': 'Docker base image ID from which to create the running instance',
+            'engine_url': 'Docker server URL where engine is listening for connections',
+        }
 
     def connect(self):
         """

--- a/niceman/resource/docker_container.py
+++ b/niceman/resource/docker_container.py
@@ -13,7 +13,7 @@ import docker
 import dockerpty
 import json
 from ..support.exceptions import CommandError, ResourceError
-from .base import Resource
+from .base import Resource, attrib
 
 import logging
 lgr = logging.getLogger('niceman.resource.docker_container')
@@ -30,28 +30,16 @@ class DockerContainer(Resource):
     id = attr.ib(default=None)
     type = attr.ib(default='docker-container')
 
-    base_image_id = attr.ib(default='ubuntu:latest')
-    engine_url = attr.ib(default='unix:///var/run/docker.sock')
+    base_image_id = attrib(default='ubuntu:latest',
+        doc="Docker base image ID from which to create the running instance")
+    engine_url = attrib(default='unix:///var/run/docker.sock',
+        doc="Docker server URL where engine is listening for connections")
 
     status = attr.ib(default=None)
 
-    # Management properties
+    # Docker client and container objects.
     _client = attr.ib(default=None)
     _container = attr.ib(default=None)
-
-    @staticmethod
-    def get_backend_properties():
-        """
-        Return the config properties specific to this resource type.
-
-        Returns
-        -------
-        dict : key = resource property, value = property
-        """
-        return {
-            'base_image_id': 'Docker base image ID from which to create the running instance',
-            'engine_url': 'Docker server URL where engine is listening for connections',
-        }
 
     def connect(self):
         """

--- a/niceman/resource/shell.py
+++ b/niceman/resource/shell.py
@@ -28,17 +28,6 @@ class Shell(Resource):
 
     status = attr.ib(default=None)
 
-    @staticmethod
-    def get_backend_properties():
-        """
-        Return the config properties specific to this resource type.
-
-        Returns
-        -------
-        dict : key = resource property, value = property description
-        """
-        return {}
-
     def create(self):
         """
         Create a running environment.

--- a/niceman/resource/shell.py
+++ b/niceman/resource/shell.py
@@ -28,6 +28,17 @@ class Shell(Resource):
 
     status = attr.ib(default=None)
 
+    @staticmethod
+    def get_backend_properties():
+        """
+        Return the config properties specific to this resource type.
+
+        Returns
+        -------
+        dict : key = resource property, value = property description
+        """
+        return {}
+
     def create(self):
         """
         Create a running environment.


### PR DESCRIPTION
The --help output is not formatted very well.

niceman create --help

Otherwise, working well. The change was to add a --backend ArgParse command which takes multiple resource-specific config parmaters

 e.g.

niceman create -r test1 -t docker-container --backend base_image_id=ubuntu:latest

