### PR TITLE
BF: Get libapt build working on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 # vim ft=yaml
 # travis-ci.org definition for NICEMAN build
 language: python
+sudo: required
+dist: precise
 
 cache:
   - apt

--- a/tools/ci/build_install_apt
+++ b/tools/ci/build_install_apt
@@ -13,6 +13,7 @@ curl -O http://security.ubuntu.com/ubuntu/pool/main/a/apt/libapt-pkg4.12_0.8.16~
 curl -O http://security.ubuntu.com/ubuntu/pool/main/a/apt/libapt-inst1.4_0.8.16~exp12ubuntu10.27_amd64.deb
 sudo dpkg --force-downgrade -i libapt-pkg-dev_0.8.16~exp12ubuntu10.27_amd64.deb libapt-pkg4.12_0.8.16~exp12ubuntu10.27_amd64.deb libapt-inst1.4_0.8.16~exp12ubuntu10.27_amd64.deb
 rm -f libapt-pkg-dev_0.8.16~exp12ubuntu10.27_amd64.deb libapt-pkg4.12_0.8.16~exp12ubuntu10.27_amd64.deb libapt-inst1.4_0.8.16~exp12ubuntu10.27_amd64.deb
+sudo apt-get -f install
 # Install python-apt version 0.9.3.5 for Python 2 and 3
 sudo apt-get install xz-utils
 curl -O http://archive.ubuntu.com/ubuntu/pool/main/p/python-apt/python-apt_$ver.tar.xz

--- a/tools/ci/build_install_apt
+++ b/tools/ci/build_install_apt
@@ -7,7 +7,10 @@ set -eux
 ver=0.9.3.5
 
 sudo apt-get build-dep python-apt
-sudo apt-get install -y --allow-downgrades  libapt-pkg-dev=0.8.16~exp12ubuntu10.27
+# sudo apt-get install -y --allow-downgrades  libapt-pkg-dev=0.8.16~exp12ubuntu10.27
+curl -O http://security.ubuntu.com/ubuntu/pool/main/a/apt/libapt-pkg-dev_0.8.16~exp12ubuntu10.27_i386.deb
+sudo dpkg --force-downgrade -i libapt-pkg-dev_0.8.16~exp12ubuntu10.27_i386.deb
+rm -f libapt-pkg-dev_0.8.16~exp12ubuntu10.27_i386.deb
 # Install python-apt version 0.9.3.5 for Python 2 and 3
 sudo apt-get install xz-utils
 curl -O http://archive.ubuntu.com/ubuntu/pool/main/p/python-apt/python-apt_$ver.tar.xz

--- a/tools/ci/build_install_apt
+++ b/tools/ci/build_install_apt
@@ -9,8 +9,8 @@ ver=0.9.3.5
 sudo apt-get build-dep python-apt
 # sudo apt-get install -y --allow-downgrades  libapt-pkg-dev=0.8.16~exp12ubuntu10.27
 curl -O http://security.ubuntu.com/ubuntu/pool/main/a/apt/libapt-pkg-dev_0.8.16~exp12ubuntu10.27_amd64.deb
-sudo dpkg --force-downgrade -i libapt-pkg-dev_0.8.16~exp12ubuntu10.27_i386.deb
-rm -f libapt-pkg-dev_0.8.16~exp12ubuntu10.27_i386.deb
+sudo dpkg --force-downgrade -i libapt-pkg-dev_0.8.16~exp12ubuntu10.27_amd64.deb
+rm -f libapt-pkg-dev_0.8.16~exp12ubuntu10.27_amd64.deb
 # Install python-apt version 0.9.3.5 for Python 2 and 3
 sudo apt-get install xz-utils
 curl -O http://archive.ubuntu.com/ubuntu/pool/main/p/python-apt/python-apt_$ver.tar.xz

--- a/tools/ci/build_install_apt
+++ b/tools/ci/build_install_apt
@@ -9,8 +9,10 @@ ver=0.9.3.5
 sudo apt-get build-dep python-apt
 # sudo apt-get install -y --allow-downgrades  libapt-pkg-dev=0.8.16~exp12ubuntu10.27
 curl -O http://security.ubuntu.com/ubuntu/pool/main/a/apt/libapt-pkg-dev_0.8.16~exp12ubuntu10.27_amd64.deb
-sudo dpkg --force-all -i libapt-pkg-dev_0.8.16~exp12ubuntu10.27_amd64.deb
-rm -f libapt-pkg-dev_0.8.16~exp12ubuntu10.27_amd64.deb
+curl -O http://security.ubuntu.com/ubuntu/pool/main/a/apt/libapt-pkg4.12_0.8.16~exp12ubuntu10.27_amd64.deb
+curl -O http://security.ubuntu.com/ubuntu/pool/main/a/apt/libapt-inst1.4_0.8.16~exp12ubuntu10.27_amd64.deb
+sudo dpkg --force-downgrade -i libapt-pkg-dev_0.8.16~exp12ubuntu10.27_amd64.deb libapt-pkg4.12_0.8.16~exp12ubuntu10.27_amd64.deb libapt-inst1.4_0.8.16~exp12ubuntu10.27_amd64.deb
+rm -f libapt-pkg-dev_0.8.16~exp12ubuntu10.27_amd64.deb libapt-pkg4.12_0.8.16~exp12ubuntu10.27_amd64.deb libapt-inst1.4_0.8.16~exp12ubuntu10.27_amd64.deb
 # Install python-apt version 0.9.3.5 for Python 2 and 3
 sudo apt-get install xz-utils
 curl -O http://archive.ubuntu.com/ubuntu/pool/main/p/python-apt/python-apt_$ver.tar.xz

--- a/tools/ci/build_install_apt
+++ b/tools/ci/build_install_apt
@@ -7,13 +7,7 @@ set -eux
 ver=0.9.3.5
 
 sudo apt-get build-dep python-apt
-# sudo apt-get install -y --allow-downgrades  libapt-pkg-dev=0.8.16~exp12ubuntu10.27
-curl -O http://security.ubuntu.com/ubuntu/pool/main/a/apt/libapt-pkg-dev_0.8.16~exp12ubuntu10.27_amd64.deb
-curl -O http://security.ubuntu.com/ubuntu/pool/main/a/apt/libapt-pkg4.12_0.8.16~exp12ubuntu10.27_amd64.deb
-curl -O http://security.ubuntu.com/ubuntu/pool/main/a/apt/libapt-inst1.4_0.8.16~exp12ubuntu10.27_amd64.deb
-sudo dpkg --force-downgrade -i libapt-pkg-dev_0.8.16~exp12ubuntu10.27_amd64.deb libapt-pkg4.12_0.8.16~exp12ubuntu10.27_amd64.deb libapt-inst1.4_0.8.16~exp12ubuntu10.27_amd64.deb
-rm -f libapt-pkg-dev_0.8.16~exp12ubuntu10.27_amd64.deb libapt-pkg4.12_0.8.16~exp12ubuntu10.27_amd64.deb libapt-inst1.4_0.8.16~exp12ubuntu10.27_amd64.deb
-sudo apt-get -f install
+sudo apt-get install -y --allow-downgrades  libapt-pkg-dev=0.8.16~exp12ubuntu10.27
 # Install python-apt version 0.9.3.5 for Python 2 and 3
 sudo apt-get install xz-utils
 curl -O http://archive.ubuntu.com/ubuntu/pool/main/p/python-apt/python-apt_$ver.tar.xz

--- a/tools/ci/build_install_apt
+++ b/tools/ci/build_install_apt
@@ -9,7 +9,7 @@ ver=0.9.3.5
 sudo apt-get build-dep python-apt
 # sudo apt-get install -y --allow-downgrades  libapt-pkg-dev=0.8.16~exp12ubuntu10.27
 curl -O http://security.ubuntu.com/ubuntu/pool/main/a/apt/libapt-pkg-dev_0.8.16~exp12ubuntu10.27_amd64.deb
-sudo dpkg --force-downgrade -i libapt-pkg-dev_0.8.16~exp12ubuntu10.27_amd64.deb
+sudo dpkg --force-all -i libapt-pkg-dev_0.8.16~exp12ubuntu10.27_amd64.deb
 rm -f libapt-pkg-dev_0.8.16~exp12ubuntu10.27_amd64.deb
 # Install python-apt version 0.9.3.5 for Python 2 and 3
 sudo apt-get install xz-utils

--- a/tools/ci/build_install_apt
+++ b/tools/ci/build_install_apt
@@ -8,7 +8,7 @@ ver=0.9.3.5
 
 sudo apt-get build-dep python-apt
 # sudo apt-get install -y --allow-downgrades  libapt-pkg-dev=0.8.16~exp12ubuntu10.27
-curl -O http://security.ubuntu.com/ubuntu/pool/main/a/apt/libapt-pkg-dev_0.8.16~exp12ubuntu10.27_i386.deb
+curl -O http://security.ubuntu.com/ubuntu/pool/main/a/apt/libapt-pkg-dev_0.8.16~exp12ubuntu10.27_amd64.deb
 sudo dpkg --force-downgrade -i libapt-pkg-dev_0.8.16~exp12ubuntu10.27_i386.deb
 rm -f libapt-pkg-dev_0.8.16~exp12ubuntu10.27_i386.deb
 # Install python-apt version 0.9.3.5 for Python 2 and 3


### PR DESCRIPTION
Starting August 1st, Travis defaults to using Ubuntu 14.04 instead of 12.04 for docker images. This broke our libapt build script.  Until we remove our dependency on python-apt, as a quick fix, I updated .travis.yml to use 12.04 again.