### PR TITLE
SSH fixture - skips within before initiating docker, renamed

### DIFF
--- a/niceman/resource/tests/test_ssh.py
+++ b/niceman/resource/tests/test_ssh.py
@@ -39,20 +39,20 @@ def setup_ssh():
     skip_if_no_network()
     skip_ssh()
     stdout, _ = Runner().run(['docker', 'ps'])
-    if '0.0.0.0:49000->22/tcp' in stdout:
+    params = {
+        'host': 'localhost',
+        'user': 'root',
+        'password': 'root',
+        'port': '49000',
+    }
+    if '0.0.0.0:{port}->22/tcp'.format(**params) in stdout:
         stop_container = False
     else:
-        params = {
-            'host': 'localhost',
-            'user': 'root',
-            'password': 'root',
-            'port': '49000',
-        }
-        args = ['docker', 
-                'run', 
-                '-d', 
-                '--rm', 
-                '-p', 
+        args = ['docker',
+                'run',
+                '-d',
+                '--rm',
+                '-p',
                 '{port}:22'.format(**params),
                 'rastasheep/ubuntu-sshd:14.04']
         stdout, _ = Runner().run(args)
@@ -62,6 +62,13 @@ def setup_ssh():
     if stop_container:
         Runner().run(['docker', 'stop', container_id])
     return
+
+
+def test_setup_ssh(setup_ssh):
+    # Rudimentary smoke test for setup_ssh so we have
+    # multiple uses for the setup_ssh
+    assert 'port' in setup_ssh
+    assert setup_ssh['host'] == 'localhost'
 
 
 def test_ssh_class(setup_ssh):

--- a/niceman/resource/tests/test_ssh.py
+++ b/niceman/resource/tests/test_ssh.py
@@ -23,7 +23,7 @@ import pytest
 from nose import SkipTest
 
 @pytest.fixture(scope='module')
-def setup_docker():
+def setup_ssh():
     """pytest fixture for tests needing a running docker container
 
     on setup, this fixture ensures that a docker container that maps 
@@ -55,7 +55,7 @@ def setup_docker():
     return
 
 
-def test_ssh_class(setup_docker):
+def test_ssh_class(setup_ssh):
 
     with swallow_logs(new_level=logging.DEBUG) as log:
 

--- a/niceman/resource/tests/test_ssh.py
+++ b/niceman/resource/tests/test_ssh.py
@@ -32,7 +32,9 @@ def setup_docker():
     on teardown, this fixture stops the docker container if it was started by 
     the fixture
     """
+
     skip_if_no_network()
+    skip_ssh()
     stdout, _ = Runner().run(['docker', 'ps'])
     if '0.0.0.0:49000->22/tcp' in stdout:
         stop_container = False
@@ -52,9 +54,8 @@ def setup_docker():
         Runner().run(['docker', 'stop', container_id])
     return
 
-def test_ssh_class(setup_docker):
 
-    skip_ssh()
+def test_ssh_class(setup_docker):
 
     with swallow_logs(new_level=logging.DEBUG) as log:
 

--- a/niceman/tests/test_tests_utils.py
+++ b/niceman/tests/test_tests_utils.py
@@ -518,3 +518,24 @@ def test_assert_is_subset_recur():
     assert_is_subset_recur([3, [2]], [3, [2]], [dict])
     assert_raises(AssertionError, assert_is_subset_recur,
                   [3, [2]], [3, [2, 1]], [dict])
+
+
+def test_skip_ssh():
+    from .utils import skip_ssh
+
+    try:
+        @skip_ssh
+        def func(x):
+            return x + 2
+
+        with patch.dict('os.environ', {'NICEMAN_TESTS_SSH': "1"}):
+            assert func(2) == 4
+    except SkipTest:
+        raise AssertionError("must have not skipped")
+
+    with patch.dict('os.environ', {'NICEMAN_TESTS_SSH': ""}):
+        try:
+            func(2)
+            assert "Must have thrown SkipTest"
+        except SkipTest:
+            pass

--- a/niceman/tests/test_tests_utils.py
+++ b/niceman/tests/test_tests_utils.py
@@ -534,8 +534,4 @@ def test_skip_ssh():
         raise AssertionError("must have not skipped")
 
     with patch.dict('os.environ', {'NICEMAN_TESTS_SSH': ""}):
-        try:
-            func(2)
-            assert "Must have thrown SkipTest"
-        except SkipTest:
-            pass
+        assert_raises(SkipTest, func, 2)


### PR DESCRIPTION
continuation to #130 
immediate pros: no docker started unless actually needed

TODOs:
- [x] test for the decorator
- [x]  pass parameters for the connection via the fixture to avoid any hardcoded specs in the test code