### PR TITLE
ENH: Large test for debian package identification

### DIFF
--- a/niceman/conftest.py
+++ b/niceman/conftest.py
@@ -13,3 +13,20 @@
 
 from niceman.tests.fixtures import niceman_cfg_path
 from niceman.formats.tests.fixtures import demo1_spec, reprozip_spec2
+
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption("--runslow", action="store_true",
+                     default=False, help="run slow tests")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow"):
+        # --runslow given in cli: do not skip slow tests
+        return
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)

--- a/niceman/distributions/tests/test_debian.py
+++ b/niceman/distributions/tests/test_debian.py
@@ -8,6 +8,8 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
 import os
+from os.path import islink
+from os.path import join, isfile
 
 from pprint import pprint
 
@@ -57,7 +59,30 @@ def test_dpkg_manager_identify_packages():
 @pytest.mark.slow
 @skip_if_no_apt_cache
 def test_check_bin_packages():
-    pass
+    # Gather files in /usr/bin and /usr/lib
+    files = list_all_files("/usr/bin") + list_all_files("/usr/lib")
+    tracer = DebTracer()
+    distributions = list(tracer.identify_distributions(files))
+    assert len(distributions) == 1
+    distribution, unknown_files = distributions[0]
+    # pprint(distribution)
+    non_local_origins = [o for o in distribution.apt_sources if o.site]
+    assert len(non_local_origins) > 0, "A non-local origin must be found"
+    for o in non_local_origins:
+        # Loop over mandatory attributes
+        for a in ["name", "component", "archive", "codename",
+                  "origin", "label", "site", "archive_uri"]:
+            assert getattr(o, a), "A non-local origin needs a " + a
+    assert len(unknown_files) == 0, "Files not found in packages: " + \
+                                    str(unknown_files)
+
+
+def list_all_files(dir):
+    files = [join(dir, f) for f in os.listdir(dir)
+             if (isfile(join(dir, f)) and
+                 not islink(join(dir, f)))]
+    return files
+
 
 # def test_find_release_file():
 #     fp = lambda p: os.path.join('/var/lib/apt/lists', p)

--- a/niceman/distributions/tests/test_debian.py
+++ b/niceman/distributions/tests/test_debian.py
@@ -54,6 +54,11 @@ def test_dpkg_manager_identify_packages():
         assert False, "A non-local origin must be found"
 
 
+@pytest.mark.slow
+@skip_if_no_apt_cache
+def test_check_bin_packages():
+    pass
+
 # def test_find_release_file():
 #     fp = lambda p: os.path.join('/var/lib/apt/lists', p)
 #


### PR DESCRIPTION
This adds a new slow test that identifies packages for files in /usr/bin/ and /usr/lib/. To run it, pass the "--runslow" parameter to py.test.  The test itself makes sure that:

- Non-local origins exist
- Non-local origins have mandatory attributes
- That all files are identified (it fails and lists any files that are not identified)