### PR TITLE
WIP: Enhancement -  batch apt package commands

### DIFF
--- a/niceman/conftest.py
+++ b/niceman/conftest.py
@@ -13,3 +13,20 @@
 
 from niceman.tests.fixtures import niceman_cfg_path
 from niceman.formats.tests.fixtures import demo1_spec, reprozip_spec2
+
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption("--runslow", action="store_true",
+                     default=False, help="run slow tests")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow"):
+        # --runslow given in cli: do not skip slow tests
+        return
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)

--- a/niceman/distributions/debian.py
+++ b/niceman/distributions/debian.py
@@ -372,7 +372,7 @@ class DebTracer(DistributionTracer):
             # Use "dpkg -s pkg" to get the installed version and arch
             # Note: "architecture" is in the dict, but may be null
             queries.append(p["name"] if not p["architecture"]
-                           else "%s:%s" % (p["name"], p["architecture"]))
+                           else "%(name)s:%(architecture)s" % p)
 
         # Find out how many packages we can query at once
         max_len = max([len(q) for q in queries])
@@ -399,7 +399,7 @@ class DebTracer(DistributionTracer):
             # find the version table in the parsed command results for the
             # current package
             r = cmd_results.get(p["name"] if not p["architecture"]
-                                else "%s:%s" % (p["name"], p["architecture"]))
+                                else "%(name)s:%(architecture)s" % p)
             if not r:
                 lgr.warning("Was unable to run dpkg -s for %s" %
                             p["name"])
@@ -413,7 +413,7 @@ class DebTracer(DistributionTracer):
         lookup_results = {}
         for r in cmd_results:
             lookup_results[r["package"]] = r
-            lookup_results["%s:%s" % (r["package"], r["architecture"])] = r
+            lookup_results["%(package)s:%(architecture)s" % r] = r
         return lookup_results
 
     def _get_pkgs_details_from_apt_cache_show(self, pkg_dicts):
@@ -421,8 +421,7 @@ class DebTracer(DistributionTracer):
         queries = []
         for p in pkg_dicts:
             # Use "dpkg -s pkg" to get the installed version and arch
-            queries.append("%s:%s=%s" % (p["name"], p["architecture"],
-                                         p["version"]))
+            queries.append("%(name)s:%(architecture)s=%(version)s" % p)
 
         # Find out how many packages we can query at once
         max_len = max([len(q) for q in queries])
@@ -447,7 +446,7 @@ class DebTracer(DistributionTracer):
         for p in pkg_dicts:
             # find the version table in the parsed command results for the
             # current package
-            r = cmd_results.get("%s:%s" % (p["name"], p["architecture"]))
+            r = cmd_results.get("%(name)s:%(architecture)s" % p)
             if not r:
                 lgr.warning("Was unable to run apt-cache show for %s" %
                             p["name"])
@@ -503,7 +502,7 @@ class DebTracer(DistributionTracer):
         queries = []
         for p in pkg_dicts:
             # Use "dpkg -s pkg" to get the installed version and arch
-            queries.append("%s:%s" % (p["name"], p["architecture"]))
+            queries.append("%(name)s:%(architecture)s" % p)
 
         # Find out how many packages we can query at once
         max_len = max([len(q) for q in queries])
@@ -525,7 +524,7 @@ class DebTracer(DistributionTracer):
         for p in pkg_dicts:
             # find the version table in the parsed command results for the
             # current package (it could be listed by name or name:arch)
-            ver = cmd_results.get("%s:%s" % (p["name"], p["architecture"]))
+            ver = cmd_results.get("%(name)s:%(architecture)s" % p)
             if not ver:
                 ver = cmd_results.get(p["name"])
             if not ver:

--- a/niceman/distributions/debian.py
+++ b/niceman/distributions/debian.py
@@ -407,15 +407,15 @@ class DebTracer(DistributionTracer):
                 lgr.warning("Was unable to run dpkg -s for %s" %
                             p.get("name"))
                 continue
-            p["architecture"] = r.get("Architecture")
-            p["version"] = r.get("Version")
+            p["architecture"] = r.get("architecture")
+            p["version"] = r.get("version")
 
     @staticmethod
     def create_lookup_from_apt_cache_show(cmd_results):
         lookup_results = {}
         for r in cmd_results:
-            lookup_results[r.get("Package")] = r
-            lookup_results["%s:%s" % (r.get("Package"),
+            lookup_results[r.get("package")] = r
+            lookup_results["%s:%s" % (r.get("package"),
                                       r.get("architecture"))] = r
         return lookup_results
 
@@ -461,12 +461,12 @@ class DebTracer(DistributionTracer):
                 lgr.warning("Was unable to run apt-cache show for %s" %
                             p.get("name"))
                 continue
-            p["source_name"] = r.get("Source_name")
-            p["source_version"] = r.get("Source_version")
-            p["size"] = r.get("Size")
-            p["md5"] = r.get("MD5sum")
-            p["sha1"] = r.get("SHA1")
-            p["sha256"] = r.get("SHA256")
+            p["source_name"] = r.get("source_name")
+            p["source_version"] = r.get("source_version")
+            p["size"] = r.get("size")
+            p["md5"] = r.get("md5")
+            p["sha1"] = r.get("sha1")
+            p["sha256"] = r.get("sha256")
 
     def _get_pkgs_install_date(self, pkg_dicts):
         # Convert package names to dpkg list filenames

--- a/niceman/distributions/debian.py
+++ b/niceman/distributions/debian.py
@@ -492,8 +492,6 @@ class DebTracer(DistributionTracer):
                     out = exc.stdout  # One file not found, so continue
                 else:
                     raise  # some other fault -- handle it above
-                    install_date = None
-                    pass
             # Parse the output and store by filename
             for outlines in out.splitlines():
                 (fname, ftime) = outlines.split(": ")

--- a/niceman/distributions/tests/test_debian.py
+++ b/niceman/distributions/tests/test_debian.py
@@ -8,6 +8,8 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
 import os
+from os.path import islink
+from os.path import join, isfile
 
 from pprint import pprint
 
@@ -57,7 +59,30 @@ def test_dpkg_manager_identify_packages():
 @pytest.mark.slow
 @skip_if_no_apt_cache
 def test_check_bin_packages():
-    pass
+    # Gather files in /usr/bin and /usr/lib
+    files = list_all_files("/usr/bin") + list_all_files("/usr/lib")
+    tracer = DebTracer()
+    distributions = list(tracer.identify_distributions(files))
+    assert len(distributions) == 1
+    distribution, unknown_files = distributions[0]
+    # pprint(distribution)
+    non_local_origins = [o for o in distribution.apt_sources if o.site]
+    assert len(non_local_origins) > 0, "A non-local origin must be found"
+    for o in non_local_origins:
+        # Loop over mandatory attributes
+        for a in ["name", "component", "archive", "codename",
+                  "origin", "label", "site", "archive_uri"]:
+            assert getattr(o, a), "A non-local origin needs a " + a
+    assert len(unknown_files) == 0, "Files not found in packages: " + \
+                                    str(unknown_files)
+
+
+def list_all_files(dir):
+    files = [join(dir, f) for f in os.listdir(dir)
+             if (isfile(join(dir, f)) and
+                 not islink(join(dir, f)))]
+    return files
+
 
 # def test_find_release_file():
 #     fp = lambda p: os.path.join('/var/lib/apt/lists', p)

--- a/niceman/distributions/tests/test_debian.py
+++ b/niceman/distributions/tests/test_debian.py
@@ -6,12 +6,14 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-
+import json
 import os
 from os.path import islink
 from os.path import join, isfile
 
 from pprint import pprint
+
+import attr
 
 from niceman.distributions.debian import DebTracer
 from niceman.distributions.debian import DEBPackage
@@ -40,7 +42,7 @@ def test_dpkg_manager_identify_packages():
     distributions = list(tracer.identify_distributions(files))
     assert len(distributions) == 1
     distribution, unknown_files = distributions[0]
-    pprint(distribution)
+    print(json.dumps(attr.asdict(distribution), indent=4))
     assert distribution.apt_sources
     # Make sure both a non-local origin was found
     for o in distribution.apt_sources:
@@ -61,11 +63,12 @@ def test_dpkg_manager_identify_packages():
 def test_check_bin_packages():
     # Gather files in /usr/bin and /usr/lib
     files = list_all_files("/usr/bin") + list_all_files("/usr/lib")
+    files = files[1:10]  # TEMPORARY!!!!
     tracer = DebTracer()
     distributions = list(tracer.identify_distributions(files))
     assert len(distributions) == 1
     distribution, unknown_files = distributions[0]
-    # pprint(distribution)
+    print(json.dumps(attr.asdict(distribution), indent=4))
     non_local_origins = [o for o in distribution.apt_sources if o.site]
     assert len(non_local_origins) > 0, "A non-local origin must be found"
     for o in non_local_origins:
@@ -114,6 +117,7 @@ def test_utf8_file():
     # Simple sanity check that the pipeline works with utf-8
     (packages, unknown_files) = \
         manager.identify_packages_from_files(files)
+    packages = manager.get_details_for_packages(packages)
     # Print for manual debugging
     pprint(unknown_files)
     pprint(packages)

--- a/niceman/distributions/tests/test_debian.py
+++ b/niceman/distributions/tests/test_debian.py
@@ -54,6 +54,11 @@ def test_dpkg_manager_identify_packages():
         assert False, "A non-local origin must be found"
 
 
+@pytest.mark.slow
+@skip_if_no_apt_cache
+def test_check_bin_packages():
+    pass
+
 # def test_find_release_file():
 #     fp = lambda p: os.path.join('/var/lib/apt/lists', p)
 #

--- a/niceman/distributions/tests/test_debian.py
+++ b/niceman/distributions/tests/test_debian.py
@@ -63,7 +63,6 @@ def test_dpkg_manager_identify_packages():
 def test_check_bin_packages():
     # Gather files in /usr/bin and /usr/lib
     files = list_all_files("/usr/bin") + list_all_files("/usr/lib")
-    files = files[1:10]  # TEMPORARY!!!!
     tracer = DebTracer()
     distributions = list(tracer.identify_distributions(files))
     assert len(distributions) == 1

--- a/niceman/support/distributions/debian.py
+++ b/niceman/support/distributions/debian.py
@@ -103,15 +103,8 @@ def parse_apt_cache_show_pkgs_output(output):
             for match in re_source.finditer(pkg["Source"]):
                 pkg["Source_name"] = match.group("source_name")
                 pkg["Source_version"] = match.group("source_version")
-        # Name the dictionary on the Package and Version
-        if "Package" in pkg and "Version" in pkg:
-            if "Architecture" in pkg:
-                pkg_ident = "%s:%s=%s" % (pkg["Package"], pkg["Architecture"],
-                                          pkg["Version"])
-            else:
-                pkg_ident = "%s=%s" % (pkg["Package"], pkg["Version"])
-            if (pkg_ident in package_info):
-                lgr.warning("Duplicate package %s found " % pkg_ident)
+        # Append package entry
+        if "Package" in pkg:
             package_info.append(pkg)
     return package_info
 

--- a/niceman/support/distributions/debian.py
+++ b/niceman/support/distributions/debian.py
@@ -75,7 +75,7 @@ def get_spec_from_release_file(content):
 
 
 def parse_apt_cache_show_pkgs_output(output):
-    package_info = {}
+    package_info = []
     # Split into entries (one per package)
     entries = filter(bool, re.split('\n(?=Package:)', output,
                                     flags=re.MULTILINE))
@@ -112,7 +112,7 @@ def parse_apt_cache_show_pkgs_output(output):
                 pkg_ident = "%s=%s" % (pkg["Package"], pkg["Version"])
             if (pkg_ident in package_info):
                 lgr.warning("Duplicate package %s found " % pkg_ident)
-            package_info[pkg_ident] = pkg
+            package_info.append(pkg)
     return package_info
 
 

--- a/niceman/support/distributions/debian.py
+++ b/niceman/support/distributions/debian.py
@@ -95,16 +95,19 @@ def parse_apt_cache_show_pkgs_output(output):
     # dictionary
     for entry in entries:
         pkg = {
-           match.group("tag"): match.group("val")
+           match.group("tag").lower(): match.group("val")
            for match in re_deb822_single_line_tag.finditer(entry)
         }
-        # Parse source line to get source version (if present)
-        if "Source" in pkg:
-            for match in re_source.finditer(pkg["Source"]):
-                pkg["Source_name"] = match.group("source_name")
-                pkg["Source_version"] = match.group("source_version")
-        # Append package entry
-        if "Package" in pkg:
+        # Process the package if one was found
+        if "package" in pkg:
+            # Parse source line to get source version (if present)
+            if "source" in pkg:
+                for match in re_source.finditer(pkg["source"]):
+                    pkg["source_name"] = match.group("source_name")
+                    pkg["source_version"] = match.group("source_version")
+            # Move md5sum to md5
+            pkg["md5"] = pkg.pop("md5sum", None)
+            # Append package entry
             package_info.append(pkg)
     return package_info
 

--- a/niceman/support/distributions/tests/test_debian.py
+++ b/niceman/support/distributions/tests/test_debian.py
@@ -147,19 +147,20 @@ Homepage: http://www.schwardtnet.de/alienblaster/
 Bugs: https://bugs.launchpad.net/ubuntu/+filebug
 Origin: Ubuntu
 """
-    out1 = [{'Architecture': 'amd64',
-             'Package': 'openssl',
-             'Status': 'install ok installed',
-             'Version': '1.0.2g-1ubuntu4.5'},
-            {'Architecture': 'amd64',
-             'Source_name': 'openssl-src',
-             'Source_version': '1.0.2g',
-             'Package': 'openssl',
-             'Version': '1.0.2g-1ubuntu4'},
-            {'Architecture': 'amd64',
-             'Source_name': 'alienblaster-src',
-             'Package': 'alienblaster',
-             'Version': '1.1.0-9'},
+    out1 = [{'architecture': 'amd64',
+             'package': 'openssl',
+             'status': 'install ok installed',
+             'version': '1.0.2g-1ubuntu4.5'},
+            {'architecture': 'amd64',
+             'source_name': 'openssl-src',
+             'source_version': '1.0.2g',
+             'package': 'openssl',
+             'version': '1.0.2g-1ubuntu4'},
+            {'architecture': 'amd64',
+             'source_name': 'alienblaster-src',
+             'package': 'alienblaster',
+             'md5': 'e53379fd0d60e0af6304af78aa8ef2b7',
+             'version': '1.1.0-9'},
             ]
     out = parse_apt_cache_show_pkgs_output(txt1)
     assert_is_subset_recur(out1, out, [dict, list])

--- a/niceman/support/distributions/tests/test_debian.py
+++ b/niceman/support/distributions/tests/test_debian.py
@@ -147,21 +147,22 @@ Homepage: http://www.schwardtnet.de/alienblaster/
 Bugs: https://bugs.launchpad.net/ubuntu/+filebug
 Origin: Ubuntu
 """
-    out1 = {'alienblaster:amd64=1.1.0-9': {'Architecture': 'amd64',
-                                           'Source_name': 'alienblaster-src',
-                                           'Package': 'alienblaster',
-                                           'Version': '1.1.0-9'},
-            'openssl:amd64=1.0.2g-1ubuntu4': {'Architecture': 'amd64',
-                                              'Source_name': 'openssl-src',
-                                              'Source_version': '1.0.2g',
-                                              'Package': 'openssl',
-                                              'Version': '1.0.2g-1ubuntu4'},
-            'openssl:amd64=1.0.2g-1ubuntu4.5': {'Architecture': 'amd64',
-                                                'Package': 'openssl',
-                                                'Status': 'install ok installed',
-                                                'Version': '1.0.2g-1ubuntu4.5'}}
+    out1 = [{'Architecture': 'amd64',
+             'Package': 'openssl',
+             'Status': 'install ok installed',
+             'Version': '1.0.2g-1ubuntu4.5'},
+            {'Architecture': 'amd64',
+             'Source_name': 'openssl-src',
+             'Source_version': '1.0.2g',
+             'Package': 'openssl',
+             'Version': '1.0.2g-1ubuntu4'},
+            {'Architecture': 'amd64',
+             'Source_name': 'alienblaster-src',
+             'Package': 'alienblaster',
+             'Version': '1.1.0-9'},
+            ]
     out = parse_apt_cache_show_pkgs_output(txt1)
-    assert_is_subset_recur(out1, out, [dict])
+    assert_is_subset_recur(out1, out, [dict, list])
 
 
 def test_parse_apt_cache_policy_pkgs_output():

--- a/niceman/tests/test_utils.py
+++ b/niceman/tests/test_utils.py
@@ -24,7 +24,7 @@ from os.path import isabs, expandvars, expanduser
 from collections import OrderedDict
 
 from ..dochelpers import exc_str
-from ..utils import updated, HashableDict
+from ..utils import updated, HashableDict, batch_process_list
 from os.path import join as opj, abspath, exists
 from ..utils import rotree, swallow_outputs, swallow_logs, setup_exceptionhook, md5sum
 from ..utils import getpwd, chpwd
@@ -433,3 +433,14 @@ def test_hashable_dict():
     d[key_a] = 1
     assert(key_b in d)
     assert(key_c not in d)
+
+
+def test_batch_process_list():
+    # Let's sum the numbers from 1 to 100 in different batches
+    l = list(range(1,101))
+    f = lambda b, p: sum(b) + p
+    s = sum(l)  # I know, it should be 5050 :)
+    assert(batch_process_list(f, l, 200, 0) == s)
+    assert(batch_process_list(f, l, 50, 0) == s)
+    assert(batch_process_list(f, l, 10, 0) == s)
+    assert(batch_process_list(f, l, 1, 0) == s)

--- a/niceman/utils.py
+++ b/niceman/utils.py
@@ -968,7 +968,7 @@ def batch_process_list(proc_func, proc_list, batch_len, start_val):
 
     Parameters
     ----------
-    proc_func : function
+    proc_func : func
       f(batch, prev_value) -> result_value
     proc_list : list
       The list to process


### PR DESCRIPTION
This branch bundles apt-cache, dpkg, and stat calls across multiple packages to speed up Debian identification. #142 

It reduces execution time of test_check_bin_packages() from 32 seconds to 2.1 seconds on my machine :)

One trick was to be able to carefully match up command results and the original list of packages. I end up placing the command results into a dictionary based on the package name (and package:arch for apt-cache and dpkg calls), and then loop through packages looking for matching results.

It's now ready for code review...