### PR TITLE
BF: retrace: Normalize paths before passing to tracers

### DIFF
--- a/niceman/interface/retrace.py
+++ b/niceman/interface/retrace.py
@@ -11,6 +11,7 @@
 
 from __future__ import unicode_literals
 
+from os.path import normpath
 import sys
 import time
 
@@ -82,7 +83,9 @@ class Retrace(Interface):
             paths += spec.get_files() or []
 
         # Convert paths to unicode
-        paths = list(map(to_unicode, paths))
+        paths = map(to_unicode, paths)
+        # The tracers assume normalized paths.
+        paths = list(map(normpath, paths))
 
         session = get_local_session()
 

--- a/niceman/interface/tests/test_retrace.py
+++ b/niceman/interface/tests/test_retrace.py
@@ -12,8 +12,8 @@ from niceman.formats import Provenance
 
 import logging
 
-from niceman.utils import swallow_logs, make_tempfile
-from niceman.tests.utils import assert_in
+from niceman.utils import swallow_logs, swallow_outputs, make_tempfile
+from niceman.tests.utils import assert_in, skip_if_no_apt_cache
 
 
 def test_retrace(reprozip_spec2):
@@ -39,3 +39,11 @@ def test_retrace_to_output_file(reprozip_spec2):
         ## loaded.
         provenance = Provenance.factory(outfile)
         assert len(provenance.get_distributions()) == 1
+
+
+@skip_if_no_apt_cache
+def test_retrace_normalize_paths():
+    # Retrace should normalize paths before passing them to tracers.
+    with swallow_outputs() as cm:
+        main(["retrace", "/sbin/../sbin/iptables"])
+        assert "name: debian" in cm.out


### PR DESCRIPTION
Otherwise `niceman retrace` will fail to detect distributions when it
is given unnormalized paths like "$PWD/../niceman/setup.py" and
"/bin/../bin/ls".

Fixes #160.