### PR TITLE
Do not store None values for url or pushurl

### DIFF
--- a/niceman/distributions/vcs.py
+++ b/niceman/distributions/vcs.py
@@ -360,12 +360,12 @@ class GitRepoShim(GitSVNRepoShim):
         # which remotes contain this commit, so we could provide this
         # possibly valuable information
         if not hexsha:  # just initialized
-            return []
+            return {}
         remote_branches = self._run_git(
             'branch -r --contains %s' % hexsha,
             expect_fail=True)
         if not remote_branches:
-            return []
+            return {}
         containing_remotes = set(x.split('/', 1)[0] for x in remote_branches)
         remotes = {}
         for remote in self._run_git('remote').splitlines():

--- a/niceman/distributions/vcs.py
+++ b/niceman/distributions/vcs.py
@@ -87,7 +87,7 @@ class GitRepo(VCSRepo):
     hexsha = attr.ib(default=None)
     describe = attr.ib(default=None)
     tracked_remote = attr.ib(default=None)
-    remotes = attr.ib(default=attr.Factory(list))
+    remotes = attr.ib(default=attr.Factory(dict))
 
 # Probably generation wouldn't be flexible enough
 #GitDistribution = get_vcs_distribution(GitRepo, 'git', 'Git')

--- a/niceman/distributions/vcs.py
+++ b/niceman/distributions/vcs.py
@@ -372,10 +372,12 @@ class GitRepoShim(GitSVNRepoShim):
             rec = {}
             for f in 'url', 'pushurl':
                 try:
-                    rec[f] = self._run_git('config remote.%s.%s' % (remote, f)
-                                           , expect_fail=True
-                                           #, expect_stderr=True
-                                           )
+                    v = self._run_git('config remote.%s.%s' % (remote, f)
+                                      , expect_fail=True
+                                      #, expect_stderr=True
+                                     )
+                    if v is not None:
+                        rec[f] = v
                 except CommandError:
                     # must have no value
                     pass

--- a/niceman/interface/tests/test_retrace_packages.py
+++ b/niceman/interface/tests/test_retrace_packages.py
@@ -38,9 +38,15 @@ def test_identify_myself():
     distributions, files = identify_distributions([__file__, '/nonexisting-for-sure'])
     assert len(distributions) == 1
     assert distributions[0].name == 'git'
-    assert distributions[0].packages[0].files == [__file__]
+    repo = distributions[0].packages[0]
+    assert repo.files == [__file__]
 
     assert files == ['/nonexisting-for-sure']
+    # there should be None rurl's or pushurl's
+    for remote in repo.remotes.values():
+        for f in 'url', 'pushurl':
+            if f in remote:
+                assert remote[f] is not None  # we do not store None's
 
 
 @with_tempfile(mkdir=True)


### PR DESCRIPTION
Ideally we might just make up a Remote(SpecObject) class, instead of
ad-hoc dict there and then it would not require custom checking there

Closes #105