### PR TITLE
BF: piputils: Be more selective when splitting show output

### DIFF
--- a/niceman/distributions/piputils.py
+++ b/niceman/distributions/piputils.py
@@ -45,7 +45,8 @@ def parse_pip_show(out):
 def _pip_batched_show(session, which_pip, pkgs):
     cmd = [which_pip, "show", "-f"]
     batch = execute_command_batch(session, cmd, pkgs)
-    entries = (stacked.split("---") for stacked, _, _ in batch)
+    sep_re = re.compile("^---$", flags=re.MULTILINE)
+    entries = (sep_re.split(stacked) for stacked, _, _ in batch)
 
     for pkg, entry in zip(pkgs, itertools.chain(*entries)):
         info = parse_pip_show(entry)

--- a/niceman/distributions/tests/test_piputils.py
+++ b/niceman/distributions/tests/test_piputils.py
@@ -7,7 +7,7 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from niceman.distributions.piputils import parse_pip_show, parse_pip_list
+from niceman.distributions import piputils
 
 
 def test_parse_pip_show():
@@ -29,7 +29,7 @@ Requires: six, funcsigs
 Files:
   pkg-0.3.0.dist-info/DESCRIPTION.rst
   pkg/__init__.py"""
-    info_files = parse_pip_show(out_files)
+    info_files = piputils.parse_pip_show(out_files)
 
     fields = {"Name", "Version", "Summary", "Home-page", "Author",
               "Author-email", "License", "Location", "Requires", "Files"}
@@ -44,7 +44,7 @@ Files:
     out_no_files = out_base + """\
 Files:
 Cannot locate installed-files.txt"""
-    info_nofiles = parse_pip_show(out_no_files)
+    info_nofiles = piputils.parse_pip_show(out_no_files)
     assert set(info_nofiles.keys()) == fields
     assert info_nofiles["Files"] == []
 
@@ -57,5 +57,5 @@ pypypypy (2.2.0)"""
     expect = [("pythis", "1.4.3", None),
               ("pythat", "0.1.0", "/local/path"),
               ("pypypypy", "2.2.0", None)]
-    result = list(parse_pip_list(out))
+    result = list(piputils.parse_pip_list(out))
     assert expect == result


### PR DESCRIPTION
When multiple packages are passed to 'pip show', the entries for each package are separated by a line that contains the marker "---".  We split the output string on "---" to get the entries.  That, however, will break if an entry's field contains "---".  Instead use a regular expression to restrict the split to lines that consist only of "---".

Re: https://github.com/ReproNim/niceman/pull/168#discussion_r168196705
