### PR TITLE
RF: multipass through Tracers

### DIFF
--- a/niceman/distributions/base.py
+++ b/niceman/distributions/base.py
@@ -243,7 +243,7 @@ class DistributionTracer(object):
                  nb_pkg_files,
                  len(unknown_files))
 
-        return list(viewvalues(found_packages)), list(unknown_files)
+        return list(viewvalues(found_packages)), unknown_files
 
     @abc.abstractmethod
     def _get_packagefields_for_files(self, files):

--- a/niceman/distributions/base.py
+++ b/niceman/distributions/base.py
@@ -237,11 +237,12 @@ class DistributionTracer(object):
                         else:
                             unknown_files.add(f)
 
-        lgr.info("%s: %d packages with %d files, and %d other files",
-                 self.__class__.__name__,
-                 len(found_packages),
-                 nb_pkg_files,
-                 len(unknown_files))
+        lgr.debug(
+            "%s: %d packages with %d files, and %d other files",
+            self.__class__.__name__,
+            len(found_packages),
+            nb_pkg_files,
+            len(unknown_files))
 
         return list(viewvalues(found_packages)), unknown_files
 

--- a/niceman/distributions/conda.py
+++ b/niceman/distributions/conda.py
@@ -325,11 +325,12 @@ class CondaTracer(DistributionTracer):
             )
             root_to_envs[root_path].append(conda_env)
 
-        lgr.info("%s: %d packages with %d files, and %d other files",
-                 self.__class__.__name__,
-                 found_package_count,
-                 total_file_count - len(unknown_files),
-                 len(unknown_files))
+        lgr.debug(
+            "%s: %d packages with %d files, and %d other files",
+            self.__class__.__name__,
+            found_package_count,
+            total_file_count - len(unknown_files),
+            len(unknown_files))
 
         # Find all the identified conda_roots
         conda_roots = root_to_envs.keys()

--- a/niceman/distributions/conda.py
+++ b/niceman/distributions/conda.py
@@ -351,4 +351,4 @@ class CondaTracer(DistributionTracer):
                 path=root_path,
                 environments=root_to_envs[root_path]
             )
-            yield dist, list(unknown_files)
+            yield dist, unknown_files

--- a/niceman/distributions/conda.py
+++ b/niceman/distributions/conda.py
@@ -21,7 +21,7 @@ from .base import SpecObject
 from .base import DistributionTracer
 from .base import Package
 from .base import TypedList
-from .piputils import pip_show, pip_packages
+from .piputils import pip_show, get_pip_packages
 from niceman.dochelpers import exc_str
 from niceman.utils import PathRoot
 
@@ -160,7 +160,7 @@ class CondaTracer(DistributionTracer):
     def _get_conda_pip_package_details(self, conda_path):
         pip = conda_path + "/bin/pip"
         try:
-            pkgs = list(pip_packages(self._session, pip))
+            pkgs = list(get_pip_packages(self._session, pip))
         except Exception as exc:
             lgr.warning("Could not determine pip packages for %s: %s",
                         conda_path, exc_str(exc))

--- a/niceman/distributions/piputils.py
+++ b/niceman/distributions/piputils.py
@@ -109,7 +109,7 @@ def parse_pip_list(out):
         yield pkg, version, location
 
 
-def pip_packages(session, which_pip, local_only=False):
+def get_pip_packages(session, which_pip, local_only=False):
     """List pip packages.
 
     Parameters

--- a/niceman/distributions/tests/test_conda.py
+++ b/niceman/distributions/tests/test_conda.py
@@ -69,7 +69,7 @@ def test_conda_manager_identify_distributions(get_conda_test_dir):
 
     (distributions, unknown_files) = dists[0]
 
-    assert unknown_files == ["/sbin/iptables"], \
+    assert unknown_files == {"/sbin/iptables"}, \
         "Exactly one file (/sbin/iptables) should not be discovered."
 
     assert len(distributions.environments) == 2, \
@@ -90,7 +90,6 @@ def test_conda_manager_identify_distributions(get_conda_test_dir):
            }
     assert_is_subset_recur(out, attr.asdict(distributions), [dict, list])
     NicemanProvenance.write(sys.stdout, distributions)
-    print(json.dumps(unknown_files, indent=4))
 
 
 def test_get_conda_env_export_exceptions():

--- a/niceman/distributions/tests/test_vcs.py
+++ b/niceman/distributions/tests/test_vcs.py
@@ -67,7 +67,7 @@ def test_git_repo_empty(git_repo_empty):
     assert_distributions(
         tracer.identify_distributions([git_repo_empty]),
         expected_length=1,
-        expected_unknown=[],
+        expected_unknown=set(),
         expected_subset={"name": "git",
                          "packages": [{"path": git_repo_empty,
                                        # We do not include repo path itself.
@@ -91,7 +91,7 @@ def test_git_repo(git_repo):
         assert_distributions(
             dists,
             expected_length=1,
-            expected_unknown=["/sbin/iptables"],
+            expected_unknown={"/sbin/iptables"},
             expected_subset={"name": "git",
                              "packages": [{"files": paths,
                                            "path": git_repo,

--- a/niceman/distributions/tests/test_venv.py
+++ b/niceman/distributions/tests/test_venv.py
@@ -59,7 +59,7 @@ def test_venv_identify_distributions(venv_test_dir):
         assert len(dists) == 1
 
         distributions, unknown_files = dists[0]
-        assert unknown_files == ["/sbin/iptables"]
+        assert unknown_files == {"/sbin/iptables"}
 
         assert len(distributions.environments) == 2
 

--- a/niceman/distributions/venv.py
+++ b/niceman/distributions/venv.py
@@ -10,6 +10,7 @@
 from collections import defaultdict
 import logging
 import os
+import os.path as op
 
 import attr
 
@@ -127,7 +128,11 @@ class VenvTracer(DistributionTracer):
                                 local=name in local_pkgs,
                                 origin_location=origin_location,
                                 files=pkg_to_found_files[name]))
-                if origin_location:
+                # op.relpath comparison is to check if to get from venv_path
+                # (which will be converted to full path if needed) to the
+                # origin_location will not go upstairs
+                if origin_location and \
+                        op.relpath(origin_location, venv_path).startswith(op.pardir):
                     unknown_files.add(origin_location)
 
             found_package_count += len(packages)

--- a/niceman/distributions/venv.py
+++ b/niceman/distributions/venv.py
@@ -148,12 +148,6 @@ class VenvTracer(DistributionTracer):
                                 python_version=self._python_version(venv_path),
                                 packages=packages))
 
-        lgr.info("%s: %d packages with %d files, and %d other files",
-                 self.__class__.__name__,
-                 found_package_count,
-                 total_file_count - len(unknown_files),
-                 len(unknown_files))
-
         if venvs:
             yield (VenvDistribution(name="venv",
                                     venv_version=self._venv_version(),

--- a/niceman/distributions/venv.py
+++ b/niceman/distributions/venv.py
@@ -13,8 +13,9 @@ import os
 
 import attr
 
+from six import iteritems
 from niceman.distributions import Distribution
-from niceman.distributions.piputils import pip_show, pip_packages
+from niceman.distributions.piputils import pip_show, get_pip_packages
 from niceman.dochelpers import exc_str
 from niceman.utils import PathRoot
 
@@ -73,7 +74,7 @@ class VenvTracer(DistributionTracer):
     def _get_package_details(self, venv_path):
         pip = venv_path + "/bin/pip"
         try:
-            pkgs = list(pip_packages(self._session, pip))
+            pkgs = list(get_pip_packages(self._session, pip))
         except Exception as exc:
             lgr.warning("Could not determine pip packages for %s: %s",
                         venv_path, exc_str(exc))
@@ -104,9 +105,9 @@ class VenvTracer(DistributionTracer):
         venvs = []
         for venv_path in venv_paths:
             package_details, file_to_pkg = self._get_package_details(venv_path)
-            local_pkgs = set(pip_packages(self._session,
-                                          venv_path + "/bin/pip",
-                                          local_only=True))
+            local_pkgs = set(get_pip_packages(self._session,
+                                              venv_path + "/bin/pip",
+                                              local_only=True))
             pkg_to_found_files = defaultdict(list)
             for path in set(unknown_files):  # Clone the set
                 # The supplied path may be relative or absolute, but

--- a/niceman/distributions/venv.py
+++ b/niceman/distributions/venv.py
@@ -121,19 +121,19 @@ class VenvTracer(DistributionTracer):
 
             packages = []
             for name, details in iteritems(package_details):
-                origin_location = details["origin_location"]
+                location = details["origin_location"]
                 packages.append(
                     VenvPackage(name=details["name"],
                                 version=details["version"],
                                 local=name in local_pkgs,
-                                origin_location=origin_location,
+                                origin_location=location,
                                 files=pkg_to_found_files[name]))
                 # op.relpath comparison is to check if to get from venv_path
                 # (which will be converted to full path if needed) to the
-                # origin_location will not go upstairs
-                if origin_location and \
-                        op.relpath(origin_location, venv_path).startswith(op.pardir):
-                    unknown_files.add(origin_location)
+                # location will not go upstairs
+                if location and \
+                        op.relpath(location, venv_path).startswith(op.pardir):
+                    unknown_files.add(location)
 
             found_package_count += len(packages)
 

--- a/niceman/distributions/venv.py
+++ b/niceman/distributions/venv.py
@@ -10,7 +10,6 @@
 from collections import defaultdict
 import logging
 import os
-import os.path as op
 
 import attr
 
@@ -18,7 +17,7 @@ from six import iteritems
 from niceman.distributions import Distribution
 from niceman.distributions.piputils import pip_show, get_pip_packages
 from niceman.dochelpers import exc_str
-from niceman.utils import PathRoot
+from niceman.utils import PathRoot, is_subpath
 
 from .base import DistributionTracer
 from .base import Package
@@ -128,11 +127,7 @@ class VenvTracer(DistributionTracer):
                                 local=name in local_pkgs,
                                 origin_location=location,
                                 files=pkg_to_found_files[name]))
-                # op.relpath comparison is to check if to get from venv_path
-                # (which will be converted to full path if needed) to the
-                # location will not go upstairs
-                if location and \
-                        op.relpath(location, venv_path).startswith(op.pardir):
+                if location and not is_subpath(location, venv_path):
                     unknown_files.add(location)
 
             found_package_count += len(packages)

--- a/niceman/distributions/venv.py
+++ b/niceman/distributions/venv.py
@@ -118,12 +118,17 @@ class VenvTracer(DistributionTracer):
                     pkg_to_found_files[file_to_pkg[fullpath]].append(
                         os.path.relpath(path, venv_path))
 
-            packages = [VenvPackage(name=details["name"],
-                                    version=details["version"],
-                                    local=name in local_pkgs,
-                                    origin_location=details["origin_location"],
-                                    files=pkg_to_found_files[name])
-                        for name, details in package_details.items()]
+            packages = []
+            for name, details in iteritems(package_details):
+                origin_location = details["origin_location"]
+                packages.append(
+                    VenvPackage(name=details["name"],
+                                version=details["version"],
+                                local=name in local_pkgs,
+                                origin_location=origin_location,
+                                files=pkg_to_found_files[name]))
+                if origin_location:
+                    unknown_files.add(origin_location)
 
             found_package_count += len(packages)
 
@@ -143,7 +148,7 @@ class VenvTracer(DistributionTracer):
                                     venv_version=self._venv_version(),
                                     path=self._venv_exe_path(),
                                     environments=venvs),
-                   list(unknown_files))
+                   unknown_files)
 
     def _python_version(self, venv_path):
         try:

--- a/niceman/interface/retrace.py
+++ b/niceman/interface/retrace.py
@@ -173,8 +173,6 @@ def identify_distributions(files, session=None):
             for env, remaining_files_to_trace in tracer.identify_distributions(
                     files_to_trace):
                 distibutions.append(env)
-                assert len(remaining_files_to_trace) <= len(files_to_trace)
-
             files_processed |= files_to_trace - remaining_files_to_trace
             files_to_trace = remaining_files_to_trace
 

--- a/niceman/interface/retrace.py
+++ b/niceman/interface/retrace.py
@@ -153,7 +153,7 @@ def identify_distributions(files, session=None):
     distibutions = []
     files_processed = set()
     for Tracer in Tracers:
-        lgr.info("Tracing using %s", Tracer)
+        lgr.debug("Tracing using %s", Tracer.__name__)
 
         # Pull out directories if the tracer can't handle them
         if Tracer.HANDLES_DIRS:
@@ -169,12 +169,18 @@ def identify_distributions(files, session=None):
         #     files, so we should not just 'continue' the loop if there is no
         #     files_to_trace
         if files_to_trace:
-            remaining_files_to_trace = set()
+            remaining_files_to_trace = files_to_trace
+            nenvs = 0
             for env, remaining_files_to_trace in tracer.identify_distributions(
                     files_to_trace):
                 distibutions.append(env)
+                nenvs += 1
             files_processed |= files_to_trace - remaining_files_to_trace
             files_to_trace = remaining_files_to_trace
+            lgr.info("%s: %d envs with %d other files remaining",
+                     Tracer.__name__,
+                     nenvs,
+                     len(files_to_trace))
 
         # Re-combine any files that were skipped
         files_to_consider = files_to_trace | files_skipped

--- a/niceman/tests/test_utils.py
+++ b/niceman/tests/test_utils.py
@@ -44,7 +44,7 @@ from ..utils import on_windows
 from ..utils import _path_
 from ..utils import to_unicode
 from ..utils import generate_unique_name
-from ..utils import PathRoot
+from ..utils import PathRoot, is_subpath
 
 from nose.tools import ok_, eq_, assert_false, assert_equal, assert_true
 
@@ -470,6 +470,25 @@ def test_pathroot():
     assert proot("/root") == "/root"
     assert proot("/root/a_root_it_is_not") == "/root"
     assert proot("/root/x/child_root") == "/root/x/child_root"
+
+
+def test_is_subpath(tmpdir):
+    tmpdir = str(tmpdir)
+
+    assert is_subpath("a/b", "a")
+    assert not is_subpath("b", "a/b")
+
+    # Partial matches in the parent directory are not false positives.
+    assert not is_subpath("abc/b", "a")
+
+    assert is_subpath("/tmp/a", "/tmp")
+    assert is_subpath("/tmp/a/b/c", "/tmp")
+    assert is_subpath("/tmp/a/b/c", "/tmp")
+    assert not is_subpath("/tmp", "/tmp/a/b/c")
+    # Same path is considered a "subpath".
+    assert is_subpath("/tmp", "/tmp")
+    # Trailing slashes don't matter.
+    assert is_subpath("/tmp/", "/tmp")
 
 
 def test_line_profile():

--- a/niceman/utils.py
+++ b/niceman/utils.py
@@ -1202,4 +1202,5 @@ def is_subpath(path, directory):
     """
     return not os.path.relpath(path, directory).startswith(os.path.pardir)
 
+
 lgr.log(5, "Done importing niceman.utils")

--- a/niceman/utils.py
+++ b/niceman/utils.py
@@ -1062,6 +1062,7 @@ def execute_command_batch(session, command, args, exception_filter=None):
     """
     cmd_length = sum(map(len, command)) + len(command)
     num_args = get_cmd_batch_len(args, cmd_length)
+    args = list(args)  # we might get in with a set
     while args:
         batch, args = args[:num_args], args[num_args:]
         try:

--- a/niceman/utils.py
+++ b/niceman/utils.py
@@ -1194,4 +1194,12 @@ class PathRoot(object):
             yield path
             path = os.path.dirname(path)
 
+
+def is_subpath(path, directory):
+    """Test whether `path` is below (or is itself) `directory`.
+
+    Symbolic links are not resolved before the check.
+    """
+    return not os.path.relpath(path, directory).startswith(os.path.pardir)
+
 lgr.log(5, "Done importing niceman.utils")


### PR DESCRIPTION
From our pair-coding session with @kyleam earlier today:
- [x] RF code to use sets for files to be tracked, instead of `list->set->list->...` 
- [ ] pass back into the list of files paths which might still be of interest for tracing by other tracers
     - [x] venv - `origin_location` (excluding the path under the venv)
     - [ ] ...conda?
        moved to #189 
- [x] actually support/do multiple passes while enhancing information in previously collected distributions/packages
- ~~~unify multiple distribution entries in the retrace output~~~ moved to #184