### PR TITLE
BF: vcs: Replace 'lstrip' with 'strip' for older Git version

### DIFF
--- a/niceman/distributions/vcs.py
+++ b/niceman/distributions/vcs.py
@@ -364,8 +364,7 @@ class GitRepoShim(GitSVNRepoShim):
             ["for-each-ref", "--contains", hexsha,
              # refs/remotes/<remote>/<name> => <remote>/<name>
              "--format=%(refname:strip=2)",
-             "refs/remotes"],
-            expect_fail=True).splitlines()
+             "refs/remotes"]).splitlines()
 
         if not remote_branches:
             return {}

--- a/niceman/distributions/vcs.py
+++ b/niceman/distributions/vcs.py
@@ -363,7 +363,7 @@ class GitRepoShim(GitSVNRepoShim):
         remote_branches = self._run_git(
             ["for-each-ref", "--contains", hexsha,
              # refs/remotes/<remote>/<name> => <remote>/<name>
-             "--format=%(refname:lstrip=2)",
+             "--format=%(refname:strip=2)",
              "refs/remotes"],
             expect_fail=True).splitlines()
 


### PR DESCRIPTION
#182 reports a failure in `test_git_repo_remotes`.  The error in that issue is an `AttributeError` that occurs because on failure `expect_fail=True` will result in None being returned, which we try to call `splitlines` on.

We, however, shouldn't actually expect an error there.  We know we're in a Git directory at that point because we have a hash.  Plus, `test_git_repo_remotes` is passing on Travis, so there has to be some difference causing the failure seen in #182.  I _think_ that is the fact that `lstrip` is a relatively recent addition to `git for-each-ref` (v2.13.0).

@chaselgrove, could you verify 1) your local Git version is pre v2.13.0 and 2) that `test_git_repo_remotes` now passes for you locally?

Closes #182.
