### PR TITLE
Fix duplicate pip entry in conda trace; add "editable" attribute for conda/pip

### DIFF
--- a/niceman/distributions/conda.py
+++ b/niceman/distributions/conda.py
@@ -14,15 +14,15 @@ from collections import defaultdict
 import attr
 import yaml
 
-from niceman.distributions import Distribution
+from niceman.distributions import Distribution, piputils
+from niceman.dochelpers import exc_str
+from niceman.utils import PathRoot
 
 from .base import SpecObject
 from .base import DistributionTracer
 from .base import Package
 from .base import TypedList
-from .piputils import pip_show
-from niceman.dochelpers import exc_str
-from niceman.utils import PathRoot
+
 
 import logging
 lgr = logging.getLogger('niceman.distributions.conda')
@@ -168,7 +168,8 @@ class CondaTracer(DistributionTracer):
 
         pip = conda_path + "/bin/pip"
         pkgs = [pkg for pkg, _  in map(self.parse_pip_package_entry, pip_deps)]
-        packages, file_to_package_map = pip_show(self._session, pip, pkgs)
+        packages, file_to_package_map = piputils.pip_show(
+            self._session, pip, pkgs)
         for entry in packages.values():
             entry["installer"] = "pip"
         return packages, file_to_package_map

--- a/niceman/distributions/conda.py
+++ b/niceman/distributions/conda.py
@@ -9,7 +9,6 @@
 """Orchestrator sub-class to provide management of the localhost environment."""
 import json
 import os
-import re
 from collections import defaultdict
 
 import attr

--- a/niceman/distributions/piputils.py
+++ b/niceman/distributions/piputils.py
@@ -102,7 +102,7 @@ def parse_pip_list(out):
     """
     pkg_re = re.compile(r"^([^(]+) \((.+)\)$", re.MULTILINE)
     for pkg, version_location in pkg_re.findall(out):
-        if "," in version_location:
+        if ", " in version_location:
             version, location = version_location.split(", ")
         else:
             version = version_location

--- a/niceman/distributions/tests/test_conda.py
+++ b/niceman/distributions/tests/test_conda.py
@@ -94,6 +94,19 @@ def test_conda_manager_identify_distributions(get_conda_test_dir):
            }
     assert_is_subset_recur(out, attr.asdict(distributions), [dict, list])
 
+    # conda packages are not repeated as "pip" packages.
+    for pkg in distributions.environments[1].packages:
+        if pkg.name == "pip":
+            assert pkg.installer is None
+
+
+def test_parse_conda_export_pip_package_entry():
+    assert CondaTracer.parse_pip_package_entry("appdirs==1.4.3") == (
+        "appdirs", None)
+    assert CondaTracer.parse_pip_package_entry(
+        "niceman (/test/repronim)==0.0.2") == (
+           "niceman", "/test/repronim")
+
 
 def test_get_conda_env_export_exceptions():
     # Mock to capture logs

--- a/niceman/distributions/tests/test_conda.py
+++ b/niceman/distributions/tests/test_conda.py
@@ -21,6 +21,7 @@ from unittest import SkipTest
 import yaml
 import attr
 from niceman.formats.niceman import NicemanProvenance
+from niceman.tests.utils import create_pymodule
 from niceman.tests.utils import skip_if_no_network, assert_is_subset_recur
 
 import json
@@ -43,13 +44,18 @@ def get_conda_test_dir():
     else:
         raise ValueError("Conda test not supported with platform %s " %
                          sys.platform)
+
+    pymod_dir = os.path.join(test_dir, "minimal_pymodule")
+    create_pymodule(pymod_dir)
+
     call("mkdir -p " + test_dir + "; "
          "cd " + test_dir + "; "
          "curl -O https://repo.continuum.io/miniconda/" + miniconda_sh + "; "
          "bash -b " + miniconda_sh + " -b -p ./miniconda; "
          "./miniconda/bin/conda create -y -n mytest python=2.7; "
          "./miniconda/bin/conda install -y xz -n mytest; "
-         "./miniconda/envs/mytest/bin/pip install rpaths;",
+         "./miniconda/envs/mytest/bin/pip install rpaths; "
+         "./miniconda/envs/mytest/bin/pip install -e " + pymod_dir + ";",
          shell=True)
     return test_dir
 
@@ -87,7 +93,12 @@ def test_conda_manager_identify_distributions(get_conda_test_dir):
                                            'name': 'pip'},
                                           {'files': ['lib/python2.7/site-packages/rpaths.py'],
                                            'installer': 'pip',
-                                           'name': 'rpaths'}
+                                           'name': 'rpaths',
+                                           'editable': False},
+                                          {"files": [],
+                                           "installer": "pip",
+                                           "name": "nmtest",
+                                           "editable": True}
                                           ]
                              }
                             ]
@@ -98,14 +109,6 @@ def test_conda_manager_identify_distributions(get_conda_test_dir):
     for pkg in distributions.environments[1].packages:
         if pkg.name == "pip":
             assert pkg.installer is None
-
-
-def test_parse_conda_export_pip_package_entry():
-    assert CondaTracer.parse_pip_package_entry("appdirs==1.4.3") == (
-        "appdirs", None)
-    assert CondaTracer.parse_pip_package_entry(
-        "niceman (/test/repronim)==0.0.2") == (
-           "niceman", "/test/repronim")
 
 
 def test_get_conda_env_export_exceptions():

--- a/niceman/distributions/tests/test_piputils.py
+++ b/niceman/distributions/tests/test_piputils.py
@@ -90,9 +90,11 @@ def test_parse_pip_list():
     out= """\
 pythis (1.4.3)
 pythat (0.1.0, /local/path)
-pypypypy (2.2.0)"""
+pypypypy (2.2.0)
+comma_in_vers (2.2,0)"""
     expect = [("pythis", "1.4.3", None),
               ("pythat", "0.1.0", "/local/path"),
-              ("pypypypy", "2.2.0", None)]
+              ("pypypypy", "2.2.0", None),
+              ("comma_in_vers", "2.2,0", None)]
     result = list(piputils.parse_pip_list(out))
     assert expect == result

--- a/niceman/distributions/tests/test_venv.py
+++ b/niceman/distributions/tests/test_venv.py
@@ -15,6 +15,7 @@ import pytest
 
 from niceman.cmd import Runner
 from niceman.utils import chpwd
+from niceman.tests.utils import create_pymodule
 from niceman.tests.utils import skip_if_no_network, assert_is_subset_recur
 from niceman.distributions.venv import VenvTracer
 
@@ -31,10 +32,15 @@ def venv_test_dir():
 
     runner = Runner()
     runner.run(["mkdir", "-p", test_dir])
+
+    pymod_dir = os.path.join(test_dir, "minimal_pymodule")
+    create_pymodule(pymod_dir)
+
     with chpwd(test_dir):
         runner.run(["virtualenv", "--python", PY_VERSION, "venv0"])
         runner.run(["virtualenv", "--python", PY_VERSION, "venv1"])
         runner.run(["./venv0/bin/pip", "install", "pyyaml"])
+        runner.run(["./venv0/bin/pip", "install", "-e", pymod_dir])
         runner.run(["./venv1/bin/pip", "install", "attrs"])
     return test_dir
 
@@ -59,11 +65,18 @@ def test_venv_identify_distributions(venv_test_dir):
         assert len(dists) == 1
 
         distributions, unknown_files = dists[0]
-        assert unknown_files == {"/sbin/iptables"}
+        assert unknown_files == {
+            "/sbin/iptables",
+            # The editable package was added by VenvTracer as an unknown file.
+            os.path.join(venv_test_dir, "minimal_pymodule")}
 
         assert len(distributions.environments) == 2
 
         expect = {"environments":
-                  [{"packages": [{"files": [paths[0]], "name": "PyYAML"}]},
-                   {"packages": [{"files": [paths[1]], "name": "attrs"}]}]}
+                  [{"packages": [{"files": [paths[0]], "name": "PyYAML",
+                                  "editable": False},
+                                 {"files": [], "name": "nmtest",
+                                  "editable": True}]},
+                   {"packages": [{"files": [paths[1]], "name": "attrs",
+                                  "editable": False}]}]}
         assert_is_subset_recur(expect, attr.asdict(distributions), [dict, list])

--- a/niceman/distributions/venv.py
+++ b/niceman/distributions/venv.py
@@ -16,7 +16,7 @@ import attr
 
 from six import iteritems
 from niceman.distributions import Distribution
-from niceman.distributions.piputils import pip_show, get_pip_packages
+from niceman.distributions import piputils
 from niceman.dochelpers import exc_str
 from niceman.utils import PathRoot, is_subpath
 
@@ -75,12 +75,12 @@ class VenvTracer(DistributionTracer):
     def _get_package_details(self, venv_path):
         pip = venv_path + "/bin/pip"
         try:
-            pkgs = list(get_pip_packages(self._session, pip))
+            pkgs = list(piputils.get_pip_packages(self._session, pip))
         except Exception as exc:
             lgr.warning("Could not determine pip packages for %s: %s",
                         venv_path, exc_str(exc))
             return
-        return pip_show(self._session, pip, pkgs)
+        return piputils.pip_show(self._session, pip, pkgs)
 
     def _is_venv_directory(self, path):
         try:
@@ -106,9 +106,9 @@ class VenvTracer(DistributionTracer):
         venvs = []
         for venv_path in venv_paths:
             package_details, file_to_pkg = self._get_package_details(venv_path)
-            local_pkgs = set(get_pip_packages(self._session,
-                                              venv_path + "/bin/pip",
-                                              local_only=True))
+            local_pkgs = set(piputils.get_pip_packages(self._session,
+                                                       venv_path + "/bin/pip",
+                                                       local_only=True))
             pkg_to_found_files = defaultdict(list)
             for path in set(unknown_files):  # Clone the set
                 # The supplied path may be relative or absolute, but

--- a/niceman/tests/utils.py
+++ b/niceman/tests/utils.py
@@ -636,6 +636,27 @@ def assert_is_subset_recur(a, b, subset_types=[]):
             raise AssertionError("Value %s != %s" % (a, b))
 
 
+def create_pymodule(directory):
+    """Create a skeleton Python module in `directory`.
+
+    Parameters
+    ----------
+    directory : str
+        Path to a non-existing directory.
+    """
+    os.makedirs(directory)
+    with open(os.path.join(directory, "setup.py"), "w") as ofh:
+        ofh.write("""\
+from setuptools import setup
+
+setup(name='nmtest',
+      version='0.1.0',
+      py_modules=['nmtest'])""")
+
+    with open(os.path.join(directory, "nmtest"), "w") as ofh:
+        ofh.write("")
+
+
 #
 # Context Managers
 #


### PR DESCRIPTION
This PR fixes two issues:

   * In 54da3757 I introduced a bug in conda traces that caused a duplicate pip listing for each conda package.

   * Starting with 6762a746, I've abused "origin_location" to mean any location, but originally it was only used for locations of editable packages.  I've renamed "origin_location" to "location" and added a field "editable" that is True if the package is editable.

WIP because

  - [X] Needs more tests, particularly for the "editable" attribute.  My hesitation here is that I'm not sure of what the best way is to set up that test.

     Update: I've now added an editable package to the venv tests.
