### PR TITLE
BF+ENH: Support latest conda release and find conda environment names

### DIFF
--- a/niceman/distributions/conda.py
+++ b/niceman/distributions/conda.py
@@ -345,10 +345,11 @@ class CondaTracer(DistributionTracer):
                 packages.append(package)
 
             # Give the distribution a name
-            if (len(conda_paths)) > 1:
-                env_name = 'conda_env-%d' % idx
+            # Determine name from path (Alt approach: use conda-env info)
+            if os.path.normpath(conda_path) == os.path.normpath(root_path):
+                env_name = "root"
             else:
-                env_name = 'conda_env'
+                env_name = os.path.basename(os.path.normpath(conda_path))
 
             # Keep track of found package count
             found_package_count += len(packages)

--- a/niceman/distributions/conda.py
+++ b/niceman/distributions/conda.py
@@ -246,31 +246,14 @@ class CondaTracer(DistributionTracer):
         return self._env_path_root(path)
 
     def _is_conda_env_directory(self, path):
-        try:
-            _, _ = self._session.execute_command(
-                'ls -ld %s/conda-meta'
-                % path
-            )
-        except Exception as exc:
-            lgr.debug("Did not detect conda env at the path %s: %s", path,
-                      exc_str(exc))
-            return False
-        return True
+        return self._session.exists('%s/conda-meta' % path)
 
     def _get_conda_root_path(self, path):
         return self._root_path_root(path)
 
     def _is_conda_root_directory(self, path):
-        try:
-            _, _ = self._session.execute_command(
-                'ls -ld %s/bin %s/envs %s/conda-meta'
-                % (path, path, path)
-            )
-        except Exception as exc:
-            lgr.debug("Did not detect conda root at the path %s: %s", path,
-                      exc_str(exc))
-            return False
-        return True
+        return all(map(self._session.exists, ('%s/%s' % (path, d) for d in
+                                              ('bin', 'envs', 'conda-meta'))))
 
     def identify_distributions(self, paths):
         conda_paths = set()

--- a/niceman/distributions/conda.py
+++ b/niceman/distributions/conda.py
@@ -105,8 +105,8 @@ class CondaTracer(DistributionTracer):
     """
 
     def _init(self):
-        self._env_path_root = PathRoot(self._is_conda_env_directory)
-        self._root_path_root = PathRoot(self._is_conda_root_directory)
+        self._get_conda_env_path = PathRoot(self._is_conda_env_path)
+        self._get_conda_root_path = PathRoot(self._is_conda_root_path)
 
     def _get_packagefields_for_files(self, files):
         raise NotImplementedError("TODO")
@@ -242,16 +242,10 @@ class CondaTracer(DistributionTracer):
                         conda_path, exc_str(exc))
         return details
 
-    def _get_conda_env_path(self, path):
-        return self._env_path_root(path)
-
-    def _is_conda_env_directory(self, path):
+    def _is_conda_env_path(self, path):
         return self._session.exists('%s/conda-meta' % path)
 
-    def _get_conda_root_path(self, path):
-        return self._root_path_root(path)
-
-    def _is_conda_root_directory(self, path):
+    def _is_conda_root_path(self, path):
         return all(map(self._session.exists, ('%s/%s' % (path, d) for d in
                                               ('bin', 'envs', 'conda-meta'))))
 

--- a/niceman/distributions/tests/test_conda.py
+++ b/niceman/distributions/tests/test_conda.py
@@ -75,9 +75,11 @@ def test_conda_manager_identify_distributions(get_conda_test_dir):
     assert len(distributions.environments) == 2, \
         "Two conda environments are expected."
 
-    out = {'environments': [{'packages': [{'files': ['bin/sqlite3'],
+    out = {'environments': [{'name': 'root',
+                             'packages': [{'files': ['bin/sqlite3'],
                                            'name': 'sqlite'}]},
-                            {'packages': [{'files': ['bin/xz'],
+                            {'name': 'mytest',
+                             'packages': [{'files': ['bin/xz'],
                                            'name': 'xz'},
                                           {'files': ['lib/python2.7/site-packages/pip/index.py'],
                                            'name': 'pip'},

--- a/niceman/distributions/tests/test_conda.py
+++ b/niceman/distributions/tests/test_conda.py
@@ -48,7 +48,7 @@ def get_conda_test_dir():
          "curl -O https://repo.continuum.io/miniconda/" + miniconda_sh + "; "
          "bash -b " + miniconda_sh + " -b -p ./miniconda; "
          "./miniconda/bin/conda create -y -n mytest python=2.7; "
-         "./miniconda/envs/mytest/bin/conda install -y xz -n mytest; "
+         "./miniconda/bin/conda install -y xz -n mytest; "
          "./miniconda/envs/mytest/bin/pip install rpaths;",
          shell=True)
     return test_dir
@@ -68,6 +68,9 @@ def test_conda_manager_identify_distributions(get_conda_test_dir):
     assert len(dists) == 1, "Exactly one Conda distribution expected."
 
     (distributions, unknown_files) = dists[0]
+
+    NicemanProvenance.write(sys.stdout, distributions)
+    print(json.dumps(unknown_files, indent=4))
 
     assert unknown_files == ["/sbin/iptables"], \
         "Exactly one file (/sbin/iptables) should not be discovered."
@@ -91,8 +94,6 @@ def test_conda_manager_identify_distributions(get_conda_test_dir):
                             ]
            }
     assert_is_subset_recur(out, attr.asdict(distributions), [dict, list])
-    NicemanProvenance.write(sys.stdout, distributions)
-    print(json.dumps(unknown_files, indent=4))
 
 
 def test_parse_conda_export_pip_package_entry():

--- a/niceman/resource/tests/test_shell.py
+++ b/niceman/resource/tests/test_shell.py
@@ -84,10 +84,20 @@ def test_source_file_crash(resource_test_dir):
         with raises(Exception):  # TODO: unify?
             session.source_script(script)
 
+
 def test_isdir():
     session = ShellSession()
     assert not session.isdir(__file__)
     assert session.isdir("/bin")
+
+
+def test_exists():
+    session = ShellSession()
+    (_, name) = tempfile.mkstemp()
+    assert session.exists(name)
+    os.remove(name)
+    assert not session.exists(name)
+    assert session.exists("/bin")
 
 
 def test_source_file_param(resource_test_dir):


### PR DESCRIPTION
This does two things:

1. Addresses #187 - The latest release of conda does not put bin/conda in the environments. Therefore this pull request changes how we search for root paths for each environment.  We also remove the assumption that there is a conda and python version for each conda environment.
2. We now determine the name of the conda environment from the path (an issue identified in #174). An alternate approach is to use "conda-env info", but since we know the conda root path, we can save a shell call by analyzing the paths instead.