### PR TITLE
ENH: conda: Extend unknown files with editable pip packages

### DIFF
--- a/niceman/distributions/conda.py
+++ b/niceman/distributions/conda.py
@@ -16,7 +16,7 @@ import yaml
 
 from niceman.distributions import Distribution, piputils
 from niceman.dochelpers import exc_str
-from niceman.utils import PathRoot
+from niceman.utils import PathRoot, is_subpath
 
 from .base import SpecObject
 from .base import DistributionTracer
@@ -296,6 +296,7 @@ class CondaTracer(DistributionTracer):
                             name=channel_name,
                             url=channel_url))
 
+                location = details.get("location")
                 # Create the package
                 package = CondaPackage(
                     name=details.get("name"),
@@ -306,11 +307,15 @@ class CondaTracer(DistributionTracer):
                     size=details.get("size"),
                     md5=details.get("md5"),
                     url=details.get("url"),
-                    location=details.get("location"),
+                    location=location,
                     editable=details.get("editable"),
                     files=pkg_to_found_files[package_name]
                 )
                 packages.append(package)
+
+                # Make editable pip packages available to other tracers.
+                if location and not is_subpath(location, conda_path):
+                    unknown_files.add(location)
 
             # Give the distribution a name
             # Determine name from path (Alt approach: use conda-env info)

--- a/niceman/distributions/tests/test_conda.py
+++ b/niceman/distributions/tests/test_conda.py
@@ -77,8 +77,9 @@ def test_conda_manager_identify_distributions(get_conda_test_dir):
 
     NicemanProvenance.write(sys.stdout, distributions)
 
-    assert unknown_files == {"/sbin/iptables"}, \
-        "Exactly one file (/sbin/iptables) should not be discovered."
+    assert unknown_files == {
+        "/sbin/iptables",
+        os.path.join(test_dir, "minimal_pymodule")}
 
     assert len(distributions.environments) == 2, \
         "Two conda environments are expected."


### PR DESCRIPTION
This is a followup to #181, which modified the tracers to do multiple passes on the set of unknown files.  The venv tracer is currently the only tracer that will extend the set of unknown files that it passes back.  It does so if it encounters a pip package with a location that is outside of the virtualenv path, which happens in the case of system-wide installs as well as editable packages.

Make conda add editable pip packages to the unknown files.  Don't worry about system-wide packages because they aren't exposed in conda environments.

Closes #189.
