### PR TITLE
ENH: Detect conda architecture (platform) #195

### DIFF
--- a/niceman/distributions/conda.py
+++ b/niceman/distributions/conda.py
@@ -27,17 +27,6 @@ from .base import TypedList
 import logging
 lgr = logging.getLogger('niceman.distributions.conda')
 
-# Provides the conda platform mapping from comda/models/enum.py
-# Note that these are python prefixes (both 'linux2' and 'linux' from python
-# map to 'linux' in conda.
-python_to_conda_platform_map = {
-    'darwin': 'osx',
-    'linux': 'linux',
-    'openbsd': 'openbsd',
-    'win': 'win',
-    'zos': 'zos',
-}
-
 
 def get_conda_platform_from_python(py_platform):
     """
@@ -45,15 +34,25 @@ def get_conda_platform_from_python(py_platform):
 
     Parameters
     ----------
-    py_platform : basestring
+    py_platform : str
         The python platform string
 
     Returns
     -------
-    basestring
+    str
         The conda platform string
 
     """
+    # Provides the conda platform mapping from conda/models/enum.py
+    # Note that these are python prefixes (both 'linux2' and 'linux' from
+    # python map to 'linux' in conda.)
+    python_to_conda_platform_map = {
+        'darwin': 'osx',
+        'linux': 'linux',
+        'openbsd': 'openbsd',
+        'win': 'win',
+        'zos': 'zos',
+    }
     for k in python_to_conda_platform_map:
         if py_platform.startswith(k):
             return python_to_conda_platform_map[k]

--- a/niceman/distributions/conda.py
+++ b/niceman/distributions/conda.py
@@ -68,6 +68,7 @@ class CondaDistribution(Distribution):
     path = attr.ib(default=None)
     conda_version = attr.ib(default=None)
     python_version = attr.ib(default=None)
+    platform = attr.ib(default=None)
     environments = TypedList(CondaEnvironment)
 
     def initiate(self, environment):
@@ -359,6 +360,7 @@ class CondaTracer(DistributionTracer):
                 name=dist_name,
                 conda_version=conda_info.get("conda_version"),
                 python_version=conda_info.get("python_version"),
+                platform=conda_info.get("platform"),
                 path=root_path,
                 environments=root_to_envs[root_path]
             )

--- a/niceman/distributions/conda.py
+++ b/niceman/distributions/conda.py
@@ -27,6 +27,37 @@ from .base import TypedList
 import logging
 lgr = logging.getLogger('niceman.distributions.conda')
 
+# Provides the conda platform mapping from comda/models/enum.py
+# Note that these are python prefixes (both 'linux2' and 'linux' from python
+# map to 'linux' in conda.
+python_to_conda_platform_map = {
+    'darwin': 'osx',
+    'linux': 'linux',
+    'openbsd': 'openbsd',
+    'win': 'win',
+    'zos': 'zos',
+}
+
+
+def get_conda_platform_from_python(py_platform):
+    """
+    Converts a python platform string to a corresponding conda platform
+
+    Parameters
+    ----------
+    py_platform : basestring
+        The python platform string
+
+    Returns
+    -------
+    basestring
+        The conda platform string
+
+    """
+    for k in python_to_conda_platform_map:
+        if py_platform.startswith(k):
+            return python_to_conda_platform_map[k]
+    return None
 
 @attr.s
 class CondaPackage(Package):

--- a/niceman/distributions/tests/test_conda.py
+++ b/niceman/distributions/tests/test_conda.py
@@ -26,7 +26,8 @@ from niceman.tests.utils import skip_if_no_network, assert_is_subset_recur
 
 import json
 
-from niceman.distributions.conda import CondaTracer
+from niceman.distributions.conda import CondaTracer, \
+    get_conda_platform_from_python
 
 
 @pytest.fixture(scope="session")
@@ -60,6 +61,10 @@ def get_conda_test_dir():
     return test_dir
 
 
+def test_get_conda_platform_from_python():
+    assert get_conda_platform_from_python("linux2") == "linux"
+    assert get_conda_platform_from_python("darwin") == "osx"
+
 def test_conda_manager_identify_distributions(get_conda_test_dir):
     # Skip if network is not available (skip_if_no_network fails with fixtures)
     test_dir = get_conda_test_dir
@@ -81,7 +86,10 @@ def test_conda_manager_identify_distributions(get_conda_test_dir):
         "/sbin/iptables",
         os.path.join(test_dir, "minimal_pymodule")}
 
-    assert distributions.platform in ["linux-64", "osx-64"], \
+
+
+    assert distributions.platform.startswith(
+        get_conda_platform_from_python(sys.platform)), \
         "A conda platform is expected."
 
     assert len(distributions.environments) == 2, \

--- a/niceman/distributions/tests/test_conda.py
+++ b/niceman/distributions/tests/test_conda.py
@@ -81,6 +81,9 @@ def test_conda_manager_identify_distributions(get_conda_test_dir):
         "/sbin/iptables",
         os.path.join(test_dir, "minimal_pymodule")}
 
+    assert distributions.platform in ["linux-64", "osx-64"], \
+        "A conda platform is expected."
+
     assert len(distributions.environments) == 2, \
         "Two conda environments are expected."
 


### PR DESCRIPTION
Since we already run conda --info, detecting the platform was surprisingly easy.  This addresses #195 .