### PR TITLE
BF: Gracefully handle no custom packages in a conda environment #194

### DIFF
--- a/niceman/distributions/conda.py
+++ b/niceman/distributions/conda.py
@@ -16,6 +16,7 @@ import yaml
 
 from niceman.distributions import Distribution, piputils
 from niceman.dochelpers import exc_str
+from niceman.support.exceptions import CommandError
 from niceman.utils import PathRoot, is_subpath
 
 from .base import SpecObject
@@ -121,9 +122,12 @@ class CondaTracer(DistributionTracer):
                 % conda_path
             )
             return iter(out.splitlines())
+        except CommandError:  # Empty conda environment
+            return iter(())
         except Exception as exc:
             lgr.warning("Could not retrieve conda-meta files in path %s: %s",
                         conda_path, exc_str(exc))
+            return iter(())
 
     def _get_conda_package_details(self, conda_path):
         packages = {}

--- a/niceman/distributions/conda.py
+++ b/niceman/distributions/conda.py
@@ -16,7 +16,6 @@ import yaml
 
 from niceman.distributions import Distribution, piputils
 from niceman.dochelpers import exc_str
-from niceman.support.exceptions import CommandError
 from niceman.utils import PathRoot, is_subpath
 
 from .base import SpecObject

--- a/niceman/distributions/conda.py
+++ b/niceman/distributions/conda.py
@@ -122,9 +122,7 @@ class CondaTracer(DistributionTracer):
                 % conda_path
             )
             return iter(out.splitlines())
-        except CommandError:  # Empty conda environment
-            return iter(())
-        except Exception as exc:
+        except Exception as exc:  # Empty conda environment (unusual situation)
             lgr.warning("Could not retrieve conda-meta files in path %s: %s",
                         conda_path, exc_str(exc))
             return iter(())

--- a/niceman/distributions/tests/test_conda.py
+++ b/niceman/distributions/tests/test_conda.py
@@ -53,6 +53,7 @@ def get_conda_test_dir():
          "curl -O https://repo.continuum.io/miniconda/" + miniconda_sh + "; "
          "bash -b " + miniconda_sh + " -b -p ./miniconda; "
          "./miniconda/bin/conda create -y -n mytest python=2.7; "
+         "./miniconda/bin/conda create -y -n empty; "
          "./miniconda/bin/conda install -y xz -n mytest; "
          "./miniconda/envs/mytest/bin/pip install rpaths; "
          "./miniconda/envs/mytest/bin/pip install -e " + pymod_dir + ";",
@@ -64,6 +65,7 @@ def test_conda_manager_identify_distributions(get_conda_test_dir):
     # Skip if network is not available (skip_if_no_network fails with fixtures)
     test_dir = get_conda_test_dir
     files = [os.path.join(test_dir, "miniconda/bin/sqlite3"),
+             os.path.join(test_dir, "miniconda/envs/empty/conda-meta/history"),
              os.path.join(test_dir, "miniconda/envs/mytest/bin/xz"),
              os.path.join(test_dir, "miniconda/envs/mytest/lib/python2.7/site-packages/pip/index.py"),
              os.path.join(test_dir, "miniconda/envs/mytest/lib/python2.7/site-packages/rpaths.py"),
@@ -79,10 +81,11 @@ def test_conda_manager_identify_distributions(get_conda_test_dir):
 
     assert unknown_files == {
         "/sbin/iptables",
-        os.path.join(test_dir, "minimal_pymodule")}
+        os.path.join(test_dir, "minimal_pymodule"),
+        os.path.join(test_dir, "miniconda/envs/empty/conda-meta/history")}
 
-    assert len(distributions.environments) == 2, \
-        "Two conda environments are expected."
+    assert len(distributions.environments) == 3, \
+        "Three conda environments are expected."
 
     out = {'environments': [{'name': 'root',
                              'packages': [{'files': ['bin/sqlite3'],


### PR DESCRIPTION
This detects and gracefully handles when there are no custom packages installed in a conda environment (so that our search for *.json is empty).  This addresses #194 .