### PR TITLE
ENH: Added a distributions module for Docker to allow tracing and ins…

### DIFF
--- a/niceman/distributions/docker.py
+++ b/niceman/distributions/docker.py
@@ -1,0 +1,169 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the niceman package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Support for Docker distribution(s)."""
+
+import attr
+import json
+import logging
+
+lgr = logging.getLogger('niceman.distributions.docker')
+
+from .base import Package
+from .base import Distribution
+from .base import DistributionTracer
+from .base import TypedList
+from .base import _register_with_representer
+from ..dochelpers import borrowdoc
+from ..support.exceptions import CommandError
+
+
+@attr.s(slots=True, frozen=True, cmp=False, hash=True)
+class DockerImage(Package):
+    """Docker image information"""
+    id = attr.ib()
+    # Optional
+    architecture = attr.ib(default=None)
+    operating_system = attr.ib(default=None)
+    docker_version = attr.ib(default=None)
+    repo_digests = attr.ib(default=None)
+    repo_tags = attr.ib(default=None)
+    created = attr.ib(default=None)
+
+_register_with_representer(DockerImage)
+
+@attr.s
+class DockerDistribution(Distribution):
+    """
+    Class to provide commands to Docker engine.
+    """
+
+    images = TypedList(DockerImage)
+
+    def initiate(self, session):
+        """
+        Perform any initialization commands needed in the environment
+        environment.
+
+        Parameters
+        ----------
+        session : object
+            The Session to work in
+        """
+
+        # Raise niceman.support.exceptions.CommandError exception if Docker 
+        # engine is not to be found.
+        session.execute_command(['docker', 'info'])
+
+    def install_packages(self, session=None):
+        """
+        Install the Docker images associated to this distribution by the
+        provenance into the environment.
+
+        Parameters
+        ----------
+        session : object
+            Session to work in
+        """
+
+        for image in self.images:
+
+            # First, look in local Docker engine.
+            try:
+                session.execute_command(['docker', 'image', 'inspect',
+                    image.id])
+                continue
+            except CommandError:
+                pass
+
+            # Then, look in repos.
+            found = False
+            for digest in image.repo_digests:
+                try:
+                    session.execute_command(['docker', 'pull', digest])
+                    session.execute_command(['docker', 'tag', image.id,
+                        image.repo_tags[0]])
+                    found = True
+                    break
+                except CommandError:
+                    pass
+
+            # Can't find the image, so complain.
+            if not found:
+                raise CommandError(cmd='docker pull {}'.format(digest),
+                    msg="Unable to locate Docker image {}".format(image.id))
+
+_register_with_representer(DockerDistribution)
+
+
+class DockerTracer(DistributionTracer):
+    """Docker image tracer
+
+    If a Docker engine is not found running in the session, the files
+    are quietly passed on to thep next tracer.
+    """
+
+    HANDLES_DIRS = False
+
+    @borrowdoc(DistributionTracer)
+    def identify_distributions(self, files):
+        if not files:
+            return
+
+        images = []
+        remaining_files = []
+
+        for file in files:
+            try:
+                image = json.loads(self._session.execute_command(['docker',
+                    'image', 'inspect', file])[0])[0]
+
+                # Fail if the Docker image has not been pushed to a repository.
+                # If the image is not in a repository, then it can't be
+                # expected to be reasonably discovered by others to reproduce.
+                if not image['RepoDigests']:
+                    raise CommandError(msg='No Docker repos found')
+
+                images.append(DockerImage(
+                    id=image['Id'],
+                    architecture=image['Architecture'],
+                    operating_system=image['Os'],
+                    docker_version=image['DockerVersion'],
+                    repo_digests=image['RepoDigests'],
+                    repo_tags=image['RepoTags'],
+                    created=image['Created']
+                ))
+            except CommandError as exc:
+                if exc.stderr.startswith('Cannot connect to the Docker daemon'):
+                    lgr.debug("Did not detect Docker engine: %s", exc)
+                    return
+                if exc.msg == 'No Docker repos found':
+                    raise CommandError(cmd="docker image inspect {}".format(
+                        file),
+                        msg="The Docker image '{}' has not been saved to a \
+repository. Please push to a repository before running the trace.".format(
+                        file))
+                remaining_files.append(file)
+
+        if not images:
+            return
+
+        dist = DockerDistribution(
+            name="docker",
+            images=images
+        )
+
+        yield dist, set(remaining_files)
+
+    @borrowdoc(DistributionTracer)
+    def _get_packagefields_for_files(self, files):
+        return
+
+    @borrowdoc(DistributionTracer)
+    def _create_package(self, **package_fields):
+        return

--- a/niceman/distributions/docker.py
+++ b/niceman/distributions/docker.py
@@ -60,7 +60,7 @@ class DockerDistribution(Distribution):
         # engine is not to be found.
         session.execute_command(['docker', 'info'])
 
-    def install_packages(self, session=None):
+    def install_packages(self, session):
         """
         Install the Docker images associated to this distribution by the
         provenance into the environment.
@@ -105,7 +105,7 @@ class DockerTracer(DistributionTracer):
     """Docker image tracer
 
     If a Docker engine is not found running in the session, the files
-    are quietly passed on to thep next tracer.
+    are quietly passed on to the next tracer.
     """
 
     HANDLES_DIRS = False
@@ -116,7 +116,7 @@ class DockerTracer(DistributionTracer):
             return
 
         images = []
-        remaining_files = []
+        remaining_files = set()
 
         for file in files:
             try:
@@ -148,7 +148,7 @@ class DockerTracer(DistributionTracer):
                         msg="The Docker image '{}' has not been saved to a \
 repository. Please push to a repository before running the trace.".format(
                         file))
-                remaining_files.append(file)
+                remaining_files.add(file)
 
         if not images:
             return
@@ -158,7 +158,7 @@ repository. Please push to a repository before running the trace.".format(
             images=images
         )
 
-        yield dist, set(remaining_files)
+        yield dist, remaining_files
 
     @borrowdoc(DistributionTracer)
     def _get_packagefields_for_files(self, files):

--- a/niceman/distributions/tests/test_docker.py
+++ b/niceman/distributions/tests/test_docker.py
@@ -15,9 +15,10 @@ from ...distributions.docker import DockerImage
 from ...distributions.docker import DockerTracer
 from ...resource.session import get_local_session
 from ...support.exceptions import CommandError
-from ...tests.utils import skip_if_no_docker_engine
+from ...tests.utils import skip_if_no_docker_engine, skip_if_no_network
 
 
+@skip_if_no_network
 @skip_if_no_docker_engine
 def test_docker_trace():
     client = docker.Client()
@@ -53,6 +54,7 @@ def test_docker_trace():
     client.remove_image(new_image['Id'])
 
 
+@skip_if_no_network
 @skip_if_no_docker_engine
 def test_docker_distribution():
 

--- a/niceman/distributions/tests/test_docker.py
+++ b/niceman/distributions/tests/test_docker.py
@@ -1,0 +1,118 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil; coding: utf-8 -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the niceman package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+
+import docker
+import pytest
+
+from ...distributions.docker import DockerDistribution
+from ...distributions.docker import DockerImage
+from ...distributions.docker import DockerTracer
+from ...resource.session import get_local_session
+from ...support.exceptions import CommandError
+from ...tests.utils import skip_if_no_docker_engine
+
+
+@skip_if_no_docker_engine
+def test_docker_trace():
+    client = docker.Client()
+    client.pull('alpine:3.6')
+
+    tracer = DockerTracer()
+
+    files = ['alpine:3.6', 'non-existant-image']
+    dist, remaining_files = next(tracer.identify_distributions(files))
+    assert dist.name == 'docker'
+    assert dist.images[0].id == 'sha256:77144d8c6bdce9b97b6d5a900f1ab85da' + \
+        '325fe8a0d1b0ba0bbff2609befa2dda'
+    assert dist.images[0].architecture == 'amd64'
+    assert dist.images[0].operating_system == 'linux'
+    assert dist.images[0].repo_digests[0] == 'alpine@sha256:f625bd3ff910a' + \
+        'd2c68a405ccc5e294d2714fc8cfe7b5d80a8331c72ad5cc7630'
+    assert dist.images[0].repo_tags[0] == 'alpine:3.6'
+    assert dist.images[0].created == '2018-01-09T21:10:38.538173323Z'
+    assert 'non-existant-image' in remaining_files
+
+    # Test tracing a local image not saved in a repository
+    container = client.create_container(image='alpine:3.6',
+        command='echo foo > test.txt')
+    new_image = client.commit(container, repository='test-container',
+        tag="001")
+    client.remove_container(container)
+    tracer = DockerTracer()
+    files = [new_image['Id']]
+    with pytest.raises(CommandError):
+        dist, _ = next(tracer.identify_distributions(files))
+
+    # Clean up docker engine
+    client.remove_image(new_image['Id'])
+
+
+@skip_if_no_docker_engine
+def test_docker_distribution():
+
+    client = docker.Client()
+    session = get_local_session()
+
+    # Verify alpine:3.5 image is not stored locally
+    try:
+        client.remove_image('sha256:6c6084ed97e5851b5d216b20ed185230127' +
+            '8584c3c6aff915272b231593f6f98')
+    except docker.errors.NotFound:
+        pass
+
+    # Install alpine:3.6 image from hub
+    client.pull('alpine:3.6')
+
+    # Test tracing valid images
+    dist = DockerDistribution('docker')
+    dist.images = [
+        DockerImage(
+            'sha256:6c6084ed97e5851b5d216b20ed1852301278584c3c6aff915272' +
+                'b231593f6f98',
+            repo_digests=['alpine@sha256:9148d069e50eee519ec45e5683e56a1' +
+                'c217b61a52ed90eb77bdce674cc212f1e'],
+            repo_tags=['alpine:3.5']
+        ),
+        DockerImage(
+            'sha256:77144d8c6bdce9b97b6d5a900f1ab85da325fe8a0d1b0ba0bbff2' +
+                '609befa2dda',
+            repo_digests=['alpine@sha256:f625bd3ff910ad2c68a405ccc5e294d2' +
+                '714fc8cfe7b5d80a8331c72ad5cc7630'],
+            repo_tags=['alpine:3.6']
+        )
+    ]
+    dist.initiate(session)
+    dist.install_packages(session)
+    alpine_3_5 = client.inspect_image(dist.images[0].id)
+    assert alpine_3_5['Id'] == 'sha256:6c6084ed97e5851b5d216b20ed18523012' + \
+        '78584c3c6aff915272b231593f6f98'
+    assert 'alpine@sha256:9148d069e50eee519ec45e5683e56a1c217b61a52ed90eb' + \
+        '77bdce674cc212f1e' in alpine_3_5['RepoDigests']
+    assert 'alpine:3.5' in alpine_3_5['RepoTags']
+    alpine_3_6 = client.inspect_image(dist.images[1].id)
+    assert alpine_3_6['Id'] == 'sha256:77144d8c6bdce9b97b6d5a900f1ab85da3' + \
+        '25fe8a0d1b0ba0bbff2609befa2dda'
+    assert 'alpine@sha256:f625bd3ff910ad2c68a405ccc5e294d2714fc8cfe7b5d80' + \
+        'a8331c72ad5cc7630' in alpine_3_6['RepoDigests']
+    assert 'alpine:3.6' in alpine_3_6['RepoTags']
+
+    # Clean up docker engine
+    client.remove_image(dist.images[0].id)
+    client.remove_image(dist.images[1].id)
+
+    # Test installing a non-existant image
+    dist.images = [
+        DockerImage(
+            'sha256:000000000000000000000000000000000000000000000000000000',
+            repo_digests=['foo@00000000000000000000000000000000000000000'],
+            repo_tags=['foo:latest']
+        )
+    ]
+    with pytest.raises(CommandError):
+        dist.install_packages(session)

--- a/niceman/interface/retrace.py
+++ b/niceman/interface/retrace.py
@@ -14,7 +14,6 @@ from __future__ import unicode_literals
 from os.path import normpath
 import sys
 import time
-from copy import copy
 
 from niceman.resource.session import get_local_session
 from .base import Interface
@@ -218,5 +217,6 @@ def get_tracer_classes():
     from niceman.distributions.conda import CondaTracer
     from niceman.distributions.venv import VenvTracer
     from niceman.distributions.vcs import VCSTracer
-    Tracers = [DebTracer, CondaTracer, VenvTracer, VCSTracer]
+    from niceman.distributions.docker import DockerTracer
+    Tracers = [DebTracer, CondaTracer, VenvTracer, VCSTracer, DockerTracer]
     return Tracers

--- a/niceman/tests/utils.py
+++ b/niceman/tests/utils.py
@@ -8,6 +8,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Miscellaneous utilities to assist with testing"""
 
+import docker
 import glob
 import inspect
 import shutil
@@ -19,6 +20,7 @@ import platform
 import multiprocessing
 import logging
 import random
+import requests
 import socket
 from six import PY2, text_type, iteritems
 from six import binary_type
@@ -428,6 +430,27 @@ def skip_if_no_docker_container(container_name='testing-container'):
                 {}".format(container_name, func.__name__))
         return func
     return decorator
+
+
+def skip_if_no_docker_engine(func):
+    """Test decorator that will skip a test if a Docker engine can't be found.
+    
+    Returns
+    -------
+    func
+        Decorator function
+    
+    Raises
+    ------
+    SkipTest
+    """
+    session = docker.Client()
+    try:
+        session.info()
+    except requests.exceptions.ConnectionError:
+        raise SkipTest("Docker not found, skipping test {}".format(
+            func.__name__))
+    return func
 
 @optional_args
 def assert_cwd_unchanged(func, ok_to_chdir=False):


### PR DESCRIPTION
…talling of Docker images to an environment running the Docker engine.

I experimented with Docker Hub and discovered that images pushed to the hub are still accessible after all the tags assigned to them are deleted. At least they have been available for the past few days since I have removed the tags from a test image.

However, if a repo is deleted, then the saved images are lost.

For this branch, the retrace and install operate at the image level. I will additionally look into retracing within a Docker container itself as discussed at the last status meeting.
