### PR TITLE
ENH: vcs(git): Use symbolic-ref to get current branch

### DIFF
--- a/niceman/distributions/tests/test_vcs.py
+++ b/niceman/distributions/tests/test_vcs.py
@@ -68,6 +68,7 @@ def test_git_repo_empty(git_repo_empty):
         expected_unknown=set(),
         expected_subset={"name": "git",
                          "packages": [{"path": git_repo_empty,
+                                       "branch": "master",
                                        # We do not include repo path itself.
                                        "files": []}]})
 

--- a/niceman/distributions/tests/test_vcs.py
+++ b/niceman/distributions/tests/test_vcs.py
@@ -6,11 +6,9 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-from collections import namedtuple
 import os
 
 import attr
-import pytest
 
 from niceman.cmd import Runner
 from niceman.distributions.vcs import VCSTracer

--- a/niceman/distributions/vcs.py
+++ b/niceman/distributions/vcs.py
@@ -403,12 +403,11 @@ class GitRepoShim(GitSVNRepoShim):
     def branch(self):
         if self._branch is None:
             try:
-                branch = self._run_git('rev-parse --abbrev-ref HEAD')
+                branch = self._run_git('symbolic-ref --short HEAD')
             except CommandError:
-                # could yet happen there is no commit here, so branch is not defined?
+                # We're in a detached state.
                 return None
-            if branch != 'HEAD':
-                self._branch = branch
+            self._branch = branch
         return self._branch
 
 


### PR DESCRIPTION
For the most part, symbolic-ref's output will be the same as that of
rev-parse --abbrev-ref, but it's a bit nicer because 1) it will return
the current branch when we're on a branch without any commits and 2)
it won't return "HEAD" when we're in a detached state.
