### PR TITLE
Prototype for exec --trace

### DIFF
--- a/niceman/formats/reprozip.py
+++ b/niceman/formats/reprozip.py
@@ -75,12 +75,11 @@ class ReprozipProvenance(Provenance):
 
         src_yaml = self._src
         if limit in {'all', 'packaged'}:
-            if 'packages' in src_yaml:
-                for package in src_yaml['packages']:
-                    if 'files' in package:
-                        files.update(package['files'])
+            for package in src_yaml.get('packages', []) or []:
+                if 'files' in package:
+                    files.update(package.get('files', []))
 
         if limit in {'all', 'loose'} and 'other_files' in src_yaml:
-            files.update(src_yaml["other_files"])
+            files.update(src_yaml.get("other_files", []))
 
         return files

--- a/niceman/interface/common_opts.py
+++ b/niceman/interface/common_opts.py
@@ -15,60 +15,7 @@ __docformat__ = 'restructuredtext'
 from niceman.support.param import Parameter
 from niceman.support.constraints import EnsureInt, EnsureNone, EnsureStr
 
-dataset_description = Parameter(
-    args=("-D", "--description",),
-    constraints=EnsureStr() | EnsureNone(),
-    doc="""short description of this dataset instance that humans can use to
-    identify the repository/location, e.g. "Precious data on my laptop.""")
-
-recursion_flag = Parameter(
-    args=("-r", "--recursive",),
+trace_opt = Parameter(
+    args=("--trace",),
     action="store_true",
-    doc="""if set, recurse into potential subdataset""")
-
-recursion_limit = Parameter(
-    args=("--recursion-limit",),
-    metavar="LEVELS",
-    constraints=EnsureInt() | EnsureNone(),
-    doc="""limit recursion into subdataset to the given number of levels""")
-
-add_to_superdataset = Parameter(
-    args=("--add-to-super",),
-    doc="""add the new dataset as a component to a super dataset""",
-    action="store_true")
-
-git_opts = Parameter(
-    args=("--git-opts",),
-    metavar='STRING',
-    constraints=EnsureStr() | EnsureNone(),
-    doc="""option string to be passed to :command:`git` calls""")
-
-annex_opts = Parameter(
-    args=("--annex-opts",),
-    metavar='STRING',
-    constraints=EnsureStr() | EnsureNone(),
-    doc="""option string to be passed to :command:`git annex` calls""")
-
-annex_init_opts = Parameter(
-    args=("--annex-init-opts",),
-    metavar='STRING',
-    constraints=EnsureStr() | EnsureNone(),
-    doc="""option string to be passed to :command:`git annex init` calls""")
-
-annex_add_opts = Parameter(
-    args=("--annex-add-opts",),
-    metavar='STRING',
-    constraints=EnsureStr() | EnsureNone(),
-    doc="""option string to be passed to :command:`git annex add` calls""")
-
-annex_get_opts = Parameter(
-    args=("--annex-get-opts",),
-    metavar='STRING',
-    constraints=EnsureStr() | EnsureNone(),
-    doc="""option string to be passed to :command:`git annex get` calls""")
-
-annex_copy_opts = Parameter(
-    args=("--annex-copy-opts",),
-    metavar='STRING',
-    constraints=EnsureStr() | EnsureNone(),
-    doc="""option string to be passed to :command:`git annex copy` calls""")
+    doc="""if set, trace execution within the environment""")

--- a/niceman/interface/exec.py
+++ b/niceman/interface/exec.py
@@ -132,7 +132,8 @@ class Exec(Interface):
                 import hashlib
                 import requests
 
-                os.makedirs(local_tracer_dir, exist_ok=True)
+                if not op.exists(local_tracer_dir):
+                    os.makedirs(local_tracer_dir)
                 resp = requests.get("https://github.com/ReproNim/reprozip/blob"
                                     "/0497b229575c67219c5925360b6e63bf8d4d5eb9"
                                     "/reprozip/native/rztracer.gz?raw=true",

--- a/niceman/interface/exec.py
+++ b/niceman/interface/exec.py
@@ -159,7 +159,7 @@ class Exec(Interface):
                 raise NotImplementedError("No --trace for --internal commands")
             session.niceman_exec(command, args)
         else:
-            session.execute_command(cmd_prefix + [command] + args, env=remote_env)
+            session.execute_command(cmd_prefix + [command] + args)  # , env=remote_env)
 
         if trace:
             # Copy all the tracing artifacts here if not present already (e.g.

--- a/niceman/interface/exec.py
+++ b/niceman/interface/exec.py
@@ -180,7 +180,9 @@ class Exec(Interface):
             local_trace_dir = op.join(
                 op.expanduser('~/.cache/niceman'), 'traces', exec_id)
             if not op.exists(local_trace_dir):
-                session.get(remote_trace_dir, local_trace_dir)
+                for fname in ["tracer.log", "trace.sqlite3"]:
+                    session.get(op.join(remote_trace_dir, fname),
+                                op.join(local_trace_dir, fname))
                 lgr.info(
                     "Copied tracing artifacts under %s", local_trace_dir)
             else:

--- a/niceman/interface/exec.py
+++ b/niceman/interface/exec.py
@@ -11,11 +11,17 @@
 
 __docformat__ = 'restructuredtext'
 
+import os.path as op
+import time
+import uuid
+
 from .base import Interface
 import niceman.interface.base # Needed for test patching
 from ..support.param import Parameter
 from ..support.constraints import EnsureStr, EnsureNone
 from ..resource import ResourceManager
+from ..resource.session import Session
+from .common_opts import trace_opt
 
 from logging import getLogger
 lgr = getLogger('niceman.api.exec')
@@ -67,10 +73,19 @@ class Exec(Interface):
             metavar='CONFIG',
             # constraints=EnsureStr(),
         ),
+        internal=Parameter(
+            args=("--internal",),
+            action="store_true",
+            doc="Instead of running a generic/any command, execute the internal"
+                " NICEMAN command available within sessions.  Known are: %s"
+                % ', '.join(Session.INTERNAL_COMMANDS)
+        ),
+        trace=trace_opt,
     )
 
     @staticmethod
-    def __call__(command, args, name=None, resource_id=None, config=None):
+    def __call__(command, args, name=None, resource_id=None, config=None,
+                 internal=False, trace=False):
         from niceman.ui import ui
         if not name and not resource_id:
             name = ui.question(
@@ -92,7 +107,65 @@ class Exec(Interface):
             raise ValueError("No resource found given the info %s" % str(resource_info))
 
         session = env_resource.get_session()
-        session.niceman_exec(command, args)
+
+        remote_env = {}
+        cmd_prefix = []
+
+        # adding two random characters to avoid collisions etc
+        # The id for the execution so we could pick up all the log and trace
+        # files for local storage
+        exec_id = "{}-{}".format(
+            time.strftime("%Y%m%d%H%M%S"),
+            str(uuid.uuid4())[:2])
+
+        if trace:
+            # Establish a "management" session first
+            mng_ses = env_resource.get_session(pty=False)
+            remote_env_full = mng_ses.query_envvars()
+            remote_niceman_dir = \
+                '{HOME}/.cache/niceman'.format(**remote_env_full)
+            remote_traces_dir = op.join(remote_niceman_dir, 'traces')
+            remote_tracer_dir = op.join(remote_niceman_dir, 'tracer')
+
+            mng_ses.mkdir(remote_tracer_dir, parents=True)
+            remote_env['NICEMAN_TRACE_DIR'] = \
+                remote_trace_dir = \
+                op.join(remote_traces_dir, exec_id)
+            mng_ses.mkdir(remote_trace_dir, parents=True)
+
+            # TODO: deposit the tracer if not there yet
+            # mng_ses.put(tracer, remote_tracer_path)
+            # TODO: augment "entry point" somehow in a generic way?
+            #    For interactive sessions with bash, we could overload ~/.bashrc
+            #    to do our wrapping of actual call to bashrc under the "tracer"
+            remote_tracer = op.join(remote_tracer_dir, "niceman_trace")
+            if not session.exists(remote_tracer):
+                session.put("/bin/echo", remote_tracer)
+            cmd_prefix = [remote_tracer]
+            # TODO: might want to add also a "marker" so within the trace
+            #       we could avoid retracing session establishing bits themselves
+            pass
+
+        # TODO: collect logs into an exec_id directory
+
+        if internal:
+            if trace:
+                raise NotImplementedError("No --trace for --internal commands")
+            session.niceman_exec(command, args)
+        else:
+            session.execute_command(cmd_prefix + [command] + args, env=remote_env)
+
+        if trace:
+            # Copy all the tracing artifacts here if not present already (e.g.
+            # if session was a local shell)
+            local_trace_dir = op.join(
+                op.expanduser('~/.cache/niceman'), 'traces', exec_id)
+            if not op.exists(local_trace_dir):
+                session.get(remote_trace_dir, local_trace_dir)
+            else:
+                lgr.debug(
+                    "Not copying %s from remote session since already exists locally",
+                    local_trace_dir)
 
         ResourceManager.set_inventory(inventory)
 

--- a/niceman/interface/exec.py
+++ b/niceman/interface/exec.py
@@ -134,14 +134,20 @@ class Exec(Interface):
             mng_ses.mkdir(remote_trace_dir, parents=True)
 
             # TODO: deposit the tracer if not there yet
-            # mng_ses.put(tracer, remote_tracer_path)
             # TODO: augment "entry point" somehow in a generic way?
             #    For interactive sessions with bash, we could overload ~/.bashrc
             #    to do our wrapping of actual call to bashrc under the "tracer"
             remote_tracer = op.join(remote_tracer_dir, "niceman_trace")
             if not session.exists(remote_tracer):
-                session.put("/bin/echo", remote_tracer)
-            cmd_prefix = [remote_tracer]
+                session.put(
+                    "/home/yoh/proj/repronim/reprozip/reprozip/native/rztracer",
+                    remote_tracer)
+            cmd_prefix = [
+                remote_tracer,
+                "--logfile", op.join(remote_trace_dir, "tracer.log"),
+                "--dbfile", op.join(remote_trace_dir, "trace.sqlite3"),
+                "--"
+            ]
             # TODO: might want to add also a "marker" so within the trace
             #       we could avoid retracing session establishing bits themselves
             pass

--- a/niceman/interface/exec.py
+++ b/niceman/interface/exec.py
@@ -171,8 +171,9 @@ class Exec(Interface):
                 session.niceman_exec(command, args)
             else:
                 out, err = session.execute_command(cmd_prefix + [command] + args)  # , env=remote_env)
-        except CommandError as error:
-            out, err = error.stdout, error.stderr
+        except CommandError as exc:
+            error = exc
+            out, err = exc.stdout, exc.stderr
 
         if trace:
             # Copy all the tracing artifacts here if not present already (e.g.

--- a/niceman/interface/exec.py
+++ b/niceman/interface/exec.py
@@ -168,6 +168,8 @@ class Exec(Interface):
                 op.expanduser('~/.cache/niceman'), 'traces', exec_id)
             if not op.exists(local_trace_dir):
                 session.get(remote_trace_dir, local_trace_dir)
+                lgr.info(
+                    "Copied tracing artifacts under %s", local_trace_dir)
             else:
                 lgr.debug(
                     "Not copying %s from remote session since already exists locally",

--- a/niceman/interface/exec.py
+++ b/niceman/interface/exec.py
@@ -175,7 +175,7 @@ class Exec(Interface):
             error = exc
             out, err = exc.stdout, exc.stderr
 
-        if trace:
+        if trace and error is None:
             # Copy all the tracing artifacts here if not present already (e.g.
             # if session was a local shell)
             local_trace_dir = op.join(

--- a/niceman/interface/exec.py
+++ b/niceman/interface/exec.py
@@ -175,6 +175,24 @@ class Exec(Interface):
                     "Not copying %s from remote session since already exists locally",
                     local_trace_dir)
 
+            from reprozip.tracer.trace import write_configuration
+            from rpaths import Path
+            # we rely on hardcoded paths in reprozip
+            write_configuration(
+                directory=Path(local_trace_dir),
+                sort_packages=False,
+                find_inputs_outputs=True)
+
+            from niceman.api import retrace
+            niceman_spec_path = op.join(local_trace_dir, "niceman.yml")
+            retrace(
+                spec=op.join(local_trace_dir, "config.yml"),
+                output_file=niceman_spec_path,
+                resource=session
+            )
+            lgr.info("NICEMAN trace %s", niceman_spec_path)
+
+
         ResourceManager.set_inventory(inventory)
 
         lgr.info("Executed the %s command in the environment %s", command,

--- a/niceman/interface/exec.py
+++ b/niceman/interface/exec.py
@@ -195,7 +195,7 @@ class Exec(Interface):
             error = exc
             out, err = exc.stdout, exc.stderr
 
-        if trace and error is None:
+        if trace:
             # Copy all the tracing artifacts here if not present already (e.g.
             # if session was a local shell)
             local_trace_dir = op.join(local_cache_dir, 'traces', exec_id)

--- a/niceman/interface/retrace.py
+++ b/niceman/interface/retrace.py
@@ -160,11 +160,11 @@ def identify_distributions(files, session=None, tracer_classes=None):
                 % max_niter)
             break
 
-        # Identify directories from the files_to_consider
-        dirs = set(filter(session.isdir, files_to_trace))
-
         for Tracer in tracer_classes:
             lgr.debug("Tracing using %s", Tracer.__name__)
+            # TODO: memoize across all loops
+            # Identify directories from the files_to_consider
+            dirs = set(filter(session.isdir, files_to_trace))
 
             # Pull out directories if the tracer can't handle them
             if Tracer.HANDLES_DIRS:

--- a/niceman/interface/retrace.py
+++ b/niceman/interface/retrace.py
@@ -61,12 +61,17 @@ class Retrace(Interface):
             metavar='output_file',
             constraints=EnsureStr() | EnsureNone(),
         ),
+        # TODO: make a common arg
+        resource=Parameter(
+            args=("--resource",),
+            doc="TODO"
+        )
     )
 
     # TODO: add a session/resource so we could trace within
     # arbitrary sessions
     @staticmethod
-    def __call__(path=None, spec=None, output_file=None):
+    def __call__(path=None, spec=None, output_file=None, resource=None):
         # heavy import -- should be delayed until actually used
 
         if not (spec or path):
@@ -87,7 +92,11 @@ class Retrace(Interface):
         # The tracers assume normalized paths.
         paths = list(map(normpath, paths))
 
-        session = get_local_session()
+        if resource:
+            # TODO: if not a session already, request a session from the resource
+            session = resource
+        else:
+            session = get_local_session()
 
         # TODO: at the moment assumes just a single distribution etc.
         #       Generalize

--- a/niceman/log.py
+++ b/niceman/log.py
@@ -175,6 +175,8 @@ class LoggerHelper(object):
         self.name = name
         self.logtarget = logtarget
         self.lgr = logging.getLogger(logtarget if logtarget is not None else name)
+        # Prevent double logging (reprozip logs at the root level).
+        self.lgr.propagate = False
 
     def _get_environ(self, var, default=None):
         return os.environ.get(self.name.upper() + '_%s' % var.upper(), default)

--- a/niceman/resource/docker_container.py
+++ b/niceman/resource/docker_container.py
@@ -166,7 +166,10 @@ class DockerSession(POSIXSession):
             raise NotImplementedError("passing env variables to docker session execution")
 
         if cwd:
-            raise NotImplementedError("handle cwd for docker")
+            # TODO: implement
+            # raise NotImplementedError("handle cwd for docker")
+            lgr.warning("cwd is not handled in docker yet")
+            pass
         # if command_env:
             # TODO: might not work - not tested it
             # command = ['export %s=%s' % k for k in command_env.items()] + command

--- a/niceman/resource/session.py
+++ b/niceman/resource/session.py
@@ -32,6 +32,9 @@ lgr = logging.getLogger('niceman.session')
 class Session(object):
     """Interface for Resources to provide interaction within that environment"""
 
+    INTERNAL_COMMANDS = ['mkdir', 'isdir', 'put', 'get', 'chown', 'chmod']
+
+
     def __attrs_post_init__(self):
         """
         Maintain both current and future session environments.
@@ -244,8 +247,8 @@ class Session(object):
         CommandError
             Exception if an invalid command argument is passed in.
         """
-        authorized_commands = ['mkdir', 'isdir', 'put', 'get', 'chown', 'chmod']
-        if command not in authorized_commands:
+
+        if command not in self.INTERNAL_COMMANDS:
             raise CommandError(cmd=command, msg="Invalid command")
 
         pargs = [] # positional args to pass to session command

--- a/niceman/resource/session.py
+++ b/niceman/resource/session.py
@@ -455,9 +455,8 @@ class POSIXSession(Session):
         object
             Decoded representation of the JSON string
         """
-        output = to_unicode(out)
-        out = {}
-        for line in output.split('\0'):
+        output = {}
+        for line in to_unicode(out).split('\0'):
             if not line:
                 continue
             split = line.split('=', 1)
@@ -465,8 +464,8 @@ class POSIXSession(Session):
                 lgr.warning(
                     "Failed to split envvar definition into key=value. Got %s", line)
                 continue
-            out[split[0]] = split[1]
-        return out
+            output[split[0]] = split[1]
+        return output
 
     @borrowdoc(Session)
     def source_script(self, command, permanent=False, diff=True, shell=None):

--- a/niceman/resource/session.py
+++ b/niceman/resource/session.py
@@ -457,7 +457,7 @@ class POSIXSession(Session):
         """
         output = to_unicode(out)
         out = {}
-        for line in output.split(b'\0'):
+        for line in output.split('\0'):
             if not line:
                 continue
             split = line.split('=', 1)

--- a/niceman/resource/tests/test_session.py
+++ b/niceman/resource/tests/test_session.py
@@ -9,6 +9,7 @@
 
 import datetime
 import docker
+import logging
 import os
 import paramiko
 import pytest
@@ -18,6 +19,7 @@ import uuid
 from ..session import get_updated_env, Session, POSIXSession
 from ...support.exceptions import CommandError
 from ..docker_container import DockerSession, PTYDockerSession
+from ...utils import swallow_logs
 from ..shell import ShellSession
 from ..ssh import SSHSession, PTYSSHSession
 from ...tests.utils import skip_ssh
@@ -268,7 +270,11 @@ def test_session_abstract_methods(testing_container, resource_session,
 
     # Check _execute_command with cwd set
     # TODO: Implement cwd parameter for _execute_command()
-    if session.__class__.__name__ != 'ShellSession':
+    if 'DockerSession' in session.__class__.__name__:
+        with swallow_logs(new_level=logging.WARN) as log:
+            session._execute_command(['cat', '/etc/hosts'], cwd='/tmp')
+            assert "cwd is not handled in docker yet" in log.out
+    elif session.__class__.__name__ != 'ShellSession':
         with pytest.raises(NotImplementedError):
             out, err = session._execute_command(['cat', '/etc/hosts'],
                 cwd='/tmp')

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,8 @@ requires = {
         'pycrypto',
         'pyOpenSSL==16.2.0',
         'requests',
+        'reprozip',
+        'rpaths',
     ],
     'debian': [
         'python-debian',


### PR DESCRIPTION
Here's the first pass of @yarikoptic's and my attempt to hook up reprozip's tracer to `niceman exec`.

To try this out

  * checkout the extract-c-tracer branch from https://github.com/ReproNim/reprozip
  * `cd  reprozip/native && make`

Then you can run `niceman exec` with the `--trace` argument.  Since we haven't deposited the binary anywhere, you can use the temporary `--tracer` option to point to the binary in the reprozip/native directory.
