### PR TITLE
DOC:  Improve documentation and reporting of config locations

### DIFF
--- a/niceman/cmdline/main.py
+++ b/niceman/cmdline/main.py
@@ -248,19 +248,6 @@ def main(args=None):
             sys.exit(1)
         except MissingConfigFileError as exc:
             # TODO: ConfigManager is not finding files in the default locations.
-            message = """
-    ERROR: Unable to locate the niceman.cfg file.
-
-    You may either specify one using the --config parameter or place one in the
-    one of following locations:
-
-    1. '/etc/niceman/niceman.cfg'
-    2. 'niceman/config' in all directories defined by $XDG_CONFIG_DIRS
-        (by default: /etc/xdg/)
-    3. 'niceman.cfg' in $XDG_CONFIG_HOME (by default: ~/.config/)
-    4. 'niceman.cfg' in the current directory
-"""
-            # print(message)
             lgr.error('%s (%s)' % (exc_str(exc), exc.__class__.__name__))
             sys.exit(1)
         except Exception as exc:

--- a/niceman/config.py
+++ b/niceman/config.py
@@ -24,7 +24,7 @@ LOCATIONS_DOC = """
     1. '/etc/niceman/niceman.cfg'
     2. 'niceman/config' in all directories defined by $XDG_CONFIG_DIRS
        (by default: /etc/xdg/)
-    3. 'niceman/niceman.cfg' in $XDG_CONFIG_HOME (by default: ~/.config/)
+    3. 'niceman/config' in $XDG_CONFIG_HOME (by default: ~/.config/)
     4. '.niceman/config', relative to the current directory
     5. 'niceman.cfg' in the current directory""".lstrip()
 

--- a/niceman/config.py
+++ b/niceman/config.py
@@ -24,7 +24,7 @@ locations_doc = """
     1. '/etc/niceman/niceman.cfg'
     2. 'niceman/config' in all directories defined by $XDG_CONFIG_DIRS
        (by default: /etc/xdg/)
-    3. 'niceman.cfg' in $XDG_CONFIG_HOME (by default: ~/.config/)
+    3. 'niceman/niceman.cfg' in $XDG_CONFIG_HOME (by default: ~/.config/)
     4. '.niceman/config', relative to the current directory
     5. 'niceman.cfg' in the current directory""".lstrip()
 

--- a/niceman/config.py
+++ b/niceman/config.py
@@ -20,7 +20,7 @@ from os.path import join as opj
 
 from .support.configparserinc import SafeConfigParserWithIncludes
 
-locations_doc = """
+LOCATIONS_DOC = """
     1. '/etc/niceman/niceman.cfg'
     2. 'niceman/config' in all directories defined by $XDG_CONFIG_DIRS
        (by default: /etc/xdg/)
@@ -43,7 +43,7 @@ class ConfigManager(SafeConfigParserWithIncludes, object):
     called later on.  Files are read and parsed in the following
     order:
 
-    {locations_doc}
+    {LOCATIONS_DOC}
 
     Moreover, the constructor takes an optional argument with a list
     of additional file names to parse afterwards.

--- a/niceman/config.py
+++ b/niceman/config.py
@@ -25,7 +25,8 @@ locations_doc = """
     2. 'niceman/config' in all directories defined by $XDG_CONFIG_DIRS
        (by default: /etc/xdg/)
     3. 'niceman.cfg' in $XDG_CONFIG_HOME (by default: ~/.config/)
-    4. 'niceman.cfg' in the current directory""".lstrip()
+    4. '.niceman/config', relative to the current directory
+    5. 'niceman.cfg' in the current directory""".lstrip()
 
 
 class ConfigManager(SafeConfigParserWithIncludes, object):

--- a/niceman/config.py
+++ b/niceman/config.py
@@ -131,7 +131,7 @@ class ConfigManager(SafeConfigParserWithIncludes, object):
         # XDG user config
         home_cfg_base_path = self.dirs.user_config_dir
         if os.path.isabs(home_cfg_base_path):
-            cfg_file_candidates.append(opj(home_cfg_base_path, 'niceman.cfg'))
+            cfg_file_candidates.append(opj(home_cfg_base_path, 'config'))
 
         # current dir config
         cfg_file_candidates.append(opj('.niceman', 'config'))

--- a/niceman/config.py
+++ b/niceman/config.py
@@ -22,10 +22,10 @@ from .support.configparserinc import SafeConfigParserWithIncludes
 
 LOCATIONS_DOC = """
     1. '/etc/niceman/niceman.cfg'
-    2. 'niceman/config' in all directories defined by $XDG_CONFIG_DIRS
+    2. 'niceman/niceman.cfg' in all directories defined by $XDG_CONFIG_DIRS
        (by default: /etc/xdg/)
-    3. 'niceman/config' in $XDG_CONFIG_HOME (by default: ~/.config/)
-    4. '.niceman/config', relative to the current directory
+    3. 'niceman/niceman.cfg' in $XDG_CONFIG_HOME (by default: ~/.config/)
+    4. '.niceman/niceman.cfg', relative to the current directory
     5. 'niceman.cfg' in the current directory""".lstrip()
 
 
@@ -124,15 +124,16 @@ class ConfigManager(SafeConfigParserWithIncludes, object):
             # system config
             '/etc/niceman/niceman.cfg']
         # XDG system config
-        cfg_file_candidates.append(opj(self.dirs.site_config_dir, 'config'))
+        cfg_file_candidates.append(opj(self.dirs.site_config_dir,
+                                       'niceman.cfg'))
 
         # XDG user config
         home_cfg_base_path = self.dirs.user_config_dir
         if os.path.isabs(home_cfg_base_path):
-            cfg_file_candidates.append(opj(home_cfg_base_path, 'config'))
+            cfg_file_candidates.append(opj(home_cfg_base_path, 'niceman.cfg'))
 
         # current dir config
-        cfg_file_candidates.append(opj('.niceman', 'config'))
+        cfg_file_candidates.append(opj('.niceman', 'niceman.cfg'))
         return cfg_file_candidates
 
     def _get_file_candidates(self):

--- a/niceman/config.py
+++ b/niceman/config.py
@@ -40,10 +40,8 @@ class ConfigManager(SafeConfigParserWithIncludes, object):
 
     Configuration files (INI syntax) in multiple location are parsed
     when a class instance is created or whenever `Config.reload()` is
-    called later on.  Files are read and parsed in the following
-    order:
-
-    {LOCATIONS_DOC}
+    called later on.  Files are read and parsed in the order described by
+    `LOCATIONS_DOC`.
 
     Moreover, the constructor takes an optional argument with a list
     of additional file names to parse afterwards.
@@ -244,7 +242,3 @@ class ConfigManager(SafeConfigParserWithIncludes, object):
             raise ValueError(
                 "Failed to obtain value from configuration for %s.%s. "
                 "Original exception was: %s" % (section, option, e))
-
-
-if ConfigManager.__doc__ is not None:  # None with python -OO
-    ConfigManager.__doc__ = ConfigManager.__doc__.format(**locals())

--- a/niceman/config.py
+++ b/niceman/config.py
@@ -20,6 +20,14 @@ from os.path import join as opj
 
 from .support.configparserinc import SafeConfigParserWithIncludes
 
+locations_doc = """
+    1. '/etc/niceman/niceman.cfg'
+    2. 'niceman/config' in all directories defined by $XDG_CONFIG_DIRS
+       (by default: /etc/xdg/)
+    3. 'niceman.cfg' in $XDG_CONFIG_HOME (by default: ~/.config/)
+    4. 'niceman.cfg' in the current directory""".lstrip()
+
+
 class ConfigManager(SafeConfigParserWithIncludes, object):
     """Central configuration registry for niceman.
 
@@ -34,11 +42,7 @@ class ConfigManager(SafeConfigParserWithIncludes, object):
     called later on.  Files are read and parsed in the following
     order:
 
-    1. '/etc/niceman/niceman.cfg'
-    2. 'niceman/config' in all directories defined by $XDG_CONFIG_DIRS
-       (by default: /etc/xdg/)
-    3. 'niceman.cfg' in $XDG_CONFIG_HOME (by default: ~/.config/)
-    4. 'niceman.cfg' in the current directory
+    {locations_doc}
 
     Moreover, the constructor takes an optional argument with a list
     of additional file names to parse afterwards.
@@ -239,3 +243,7 @@ class ConfigManager(SafeConfigParserWithIncludes, object):
             raise ValueError(
                 "Failed to obtain value from configuration for %s.%s. "
                 "Original exception was: %s" % (section, option, e))
+
+
+if ConfigManager.__doc__ is not None:  # None with python -OO
+    ConfigManager.__doc__ = ConfigManager.__doc__.format(**locals())

--- a/niceman/resource/base.py
+++ b/niceman/resource/base.py
@@ -20,7 +20,7 @@ from os.path import join as opj
 from glob import glob
 import os.path
 
-from ..config import ConfigManager, locations_doc
+from ..config import ConfigManager, LOCATIONS_DOC
 from ..dochelpers import exc_str
 from ..support.exceptions import ResourceError
 from ..support.exceptions import MissingConfigError, MissingConfigFileError
@@ -216,7 +216,7 @@ class ResourceManager(object):
                 "You must specify it using --config "
                 "or place it in any of the following locations:\n\n"
                 "{}\n\n".format(config_path or config,
-                                dedent_docstring(locations_doc)))
+                                dedent_docstring(LOCATIONS_DOC)))
 
         return cm
 

--- a/niceman/resource/base.py
+++ b/niceman/resource/base.py
@@ -20,7 +20,7 @@ from os.path import join as opj
 from glob import glob
 import os.path
 
-from ..config import ConfigManager
+from ..config import ConfigManager, locations_doc
 from ..dochelpers import exc_str
 from ..support.exceptions import ResourceError
 from ..support.exceptions import MissingConfigError, MissingConfigFileError
@@ -210,8 +210,13 @@ class ResourceManager(object):
             config = ui.question("Enter a config file", default="niceman.cfg")
             cm = get_cm(config_path=config)
         if len(cm._sections) == 1:
+            from ..interface.base import dedent_docstring
             raise MissingConfigFileError(
-                "Unable to locate config file: {}".format(config_path or config))
+                "Unable to locate config file: {}\n"
+                "You must specify it using --config "
+                "or place it in any of the following locations:\n\n"
+                "{}\n\n".format(config_path or config,
+                                dedent_docstring(locations_doc)))
 
         return cm
 

--- a/niceman/resource/base.py
+++ b/niceman/resource/base.py
@@ -211,7 +211,7 @@ class ResourceManager(object):
             cm = get_cm(config_path=config)
         if len(cm._sections) == 1:
             raise MissingConfigFileError(
-                "Unable to locate config file: {}".format(config_path))
+                "Unable to locate config file: {}".format(config_path or config))
 
         return cm
 

--- a/niceman/tests/fixtures.py
+++ b/niceman/tests/fixtures.py
@@ -18,7 +18,7 @@ from niceman.cmd import Runner
 from niceman.tests.utils import skip_if_no_network
 from niceman.utils import chpwd
 
-# Substitutes in for user's ~/.config/niceman.cfg file
+# Substitutes in for user's ~/.config/niceman/niceman.cfg file
 CONFIGURATION = [
     NICEMAN_CFG_PATH
 ]

--- a/niceman/tests/fixtures.py
+++ b/niceman/tests/fixtures.py
@@ -18,7 +18,7 @@ from niceman.cmd import Runner
 from niceman.tests.utils import skip_if_no_network
 from niceman.utils import chpwd
 
-# Substitutes in for user's ~/.config/niceman/niceman.cfg file
+# Substitutes in for user's ~/.config/niceman/config file
 CONFIGURATION = [
     NICEMAN_CFG_PATH
 ]


### PR DESCRIPTION

This PR

  * Mentions the allowed config locations in `MissingConfigFileError`s message so that the user knows how to fix the problem.

  * Mentions `$PWD/.niceman/config` in the locations list.

  * Corrects the documented location of the config file in `XDG_CONFIG_HOME`.

  * Changes the `XDG_CONFIG_HOME` location from `$XDG_CONFIG_HOME/niceman/niceman.cfg` to `$XDG_CONFIG_HOME/niceman/config` for consistency with other names.
