### PR TITLE
BF: Add kludge to load Git and SVN distributions

### DIFF
--- a/niceman/distributions/base.py
+++ b/niceman/distributions/base.py
@@ -93,8 +93,15 @@ class Distribution(SpecObject):
         distribution : object
             Distribution class or its instance (when provenance is not None)
         """
-        class_name = distribution_type.capitalize() + 'Distribution'
-        module = import_module('niceman.distributions.' + distribution_type.lower())
+        # Handle distributions that don't follow the assumed naming structure.
+        special_dists = {"svn": "SVNDistribution"}
+        special_modules = {"git": "vcs", "svn": "vcs"}
+
+        dlower = distribution_type.lower()
+        class_name = special_dists.get(dlower,
+                                       dlower.capitalize() + 'Distribution')
+        module = import_module('niceman.distributions.' +
+                               special_modules.get(dlower, dlower))
         class_ = getattr(module, class_name)
         return class_ if provenance is None else class_(**provenance)
 

--- a/niceman/formats/tests/test_niceman.py
+++ b/niceman/formats/tests/test_niceman.py
@@ -19,6 +19,10 @@ from niceman.distributions.conda import CondaPackage
 from niceman.distributions.debian import APTSource
 from niceman.distributions.debian import DEBPackage
 from niceman.distributions.debian import DebianDistribution
+from niceman.distributions.vcs import GitDistribution
+from niceman.distributions.vcs import GitRepo
+from niceman.distributions.vcs import SVNDistribution
+from niceman.distributions.vcs import SVNRepo
 from niceman.distributions.venv import VenvDistribution
 from niceman.distributions.venv import VenvEnvironment
 from niceman.distributions.venv import VenvPackage
@@ -111,6 +115,12 @@ def test_spec_round_trip():
                         path="/path/to/miniconda3",
                         packages=[
                             CondaPackage(name="condapkg2")])]),
+            GitDistribution(
+                name="git",
+                packages=[GitRepo(path="/path/to/repo")]),
+            SVNDistribution(
+                name="svn",
+                packages=[SVNRepo(path="/path/to/repo")]),
             VenvDistribution(
                 name="venv0",
                 path="/usr/bin/virtualenv",


### PR DESCRIPTION
NicemanProvenance is unable to load a spec that includes a
GitDistribution or SVNDistribution because these don't follow the
expected naming conventions.  Specifically, GitDistribution and
SVNDistribution are in the module "vcs" rather than "git" and "svn",
respectively, and the "SVN" in SVNDistribution is all uppercase.

We could (1) adjust Distribution.factory to treat SVN and Git as
special cases, (2) restructure things so that the SVN and Git follow
the expected naming pattern, or (3) maintain a mapping from
distribution["name"] -> module.class.

Go with (1) for now because it involves the fewest changes.

Fixes #222.