### PR TITLE
debian: Improve warning about multiple packages found by dpkg-query -S

### DIFF
--- a/niceman/distributions/debian.py
+++ b/niceman/distributions/debian.py
@@ -365,7 +365,7 @@ class DebTracer(DistributionTracer):
             for outline in out.splitlines():
                 # Parse package name (architecture) and path
                 # TODO: Handle query of /bin/sh better
-                outdict = parse_dpkgquery_line(outline)
+                outdict = self._parse_dpkgquery_line(outline)
                 if not outdict:
                     lgr.debug("Skipping line %s", outline)
                     continue
@@ -611,3 +611,11 @@ class DebTracer(DistributionTracer):
                 # specific attempts.
                 pass
         return date
+
+    def _parse_dpkgquery_line(self, line):
+        res = parse_dpkgquery_line(line)
+        if ',' in line:
+            if self._session.isdir(res["path"]):
+                return None
+            lgr.warning("dpkg-query line has multiple packages (%s)", line)
+        return res

--- a/niceman/distributions/debian.py
+++ b/niceman/distributions/debian.py
@@ -614,7 +614,7 @@ class DebTracer(DistributionTracer):
 
     def _parse_dpkgquery_line(self, line):
         res = parse_dpkgquery_line(line)
-        if ',' in line:
+        if res and res.pop("pkgs_rest"):
             if self._session.isdir(res["path"]):
                 return None
             lgr.warning("dpkg-query line has multiple packages (%s)", line)

--- a/niceman/distributions/tests/test_debian.py
+++ b/niceman/distributions/tests/test_debian.py
@@ -24,7 +24,6 @@ import pytest
 
 import mock
 
-from niceman.support.exceptions import CommandError
 from niceman.utils import swallow_logs
 from niceman.tests.utils import skip_if_no_apt_cache
 

--- a/niceman/distributions/tests/test_debian.py
+++ b/niceman/distributions/tests/test_debian.py
@@ -128,20 +128,6 @@ def test_utf8_file():
         assert True
 
 
-def test_parse_dpkgquery_line():
-    parse = DebTracer._parse_dpkgquery_line
-    assert parse('zlib1g:i386: /lib/i386-linux-gnu/libz.so.1.2.8') == \
-        {'name': 'zlib1g', 'architecture': 'i386', 'path': '/lib/i386-linux-gnu/libz.so.1.2.8'}
-
-    assert parse('fail2ban: /usr/bin/fail2ban-client') == \
-           {'name': 'fail2ban', 'path': '/usr/bin/fail2ban-client'}
-
-    assert parse('fsl-5.0-eddy-nonfree, fsl-5.0-core: /usr/lib/fsl/5.0') == \
-           {'name': 'fsl-5.0-eddy-nonfree', 'path': '/usr/lib/fsl/5.0'}
-
-    assert parse('diversion by dash from: /bin/sh') is None
-
-
 def test_get_packagefields_for_files():
     manager = DebTracer()
     # TODO: mock! and bring back afni and fail2ban

--- a/niceman/distributions/tests/test_debian.py
+++ b/niceman/distributions/tests/test_debian.py
@@ -171,24 +171,25 @@ def test_parse_dpkgquery_line():
     parse = DebTracer()._parse_dpkgquery_line
 
     mock_values = {
-        "line": {"name": "pkg",
-                 "path": "/path/to/file"},
-        "comma,line,dir": {"name": "pkg",
-                           "path": os.getcwd()},
-        "comma,line,file": {"name": "pkg",
-                            "path": __file__}
+        "unique": {"name": "pkg",
+                   "path": "/path/to/file",
+                   "pkgs_rest": None},
+        "multi_dir": {"name": "pkg",
+                      "path": os.getcwd(),
+                      "pkgs_rest": ", more, packages"},
+        "multi_file": {"name": "pkg",
+                       "path": __file__,
+                       "pkgs_rest": ", more, packages"}
     }
 
     with mock.patch("niceman.distributions.debian.parse_dpkgquery_line",
                     mock_values.get):
-        assert parse("line") == {"name": "pkg",
-                                 "path": "/path/to/file"}
+        assert parse("unique") == {"name": "pkg",
+                                   "path": "/path/to/file"}
+        assert parse("multi_dir") is None
         with swallow_logs(new_level=logging.WARNING) as log:
-            assert parse("comma,line,dir") is None
-            assert not any("multiple packages " in ln for ln in log.lines)
-
-            assert parse("comma,line,file") == {"name": "pkg",
-                                                "path": __file__}
+            assert parse("multi_file") == {"name": "pkg",
+                                           "path": __file__}
             assert any("multiple packages " in ln for ln in log.lines)
 
 

--- a/niceman/support/distributions/debian.py
+++ b/niceman/support/distributions/debian.py
@@ -233,3 +233,19 @@ def get_apt_release_file_names(url, url_suite):
         filename = url
     return ["/var/lib/apt/lists/" + filename + "_Release",
             "/var/lib/apt/lists/" + filename + "_InRelease"]
+
+
+def parse_dpkgquery_line(line):
+    result_re = re.compile(
+        "(?P<name>[^,:]+)(:(?P<architecture>[^,:]+))?(,.*)?: (?P<path>.*)$"
+    )
+    if line.startswith('diversion '):
+        return None  # we are ignoring diversion details ATM  TODO
+    if ',' in line:
+        lgr.warning("dpkg-query line has multiple packages (%s)" % line)
+    res = result_re.match(line)
+    if res:
+        res = res.groupdict()
+        if res['architecture'] is None:
+            res.pop('architecture')
+    return res

--- a/niceman/support/distributions/debian.py
+++ b/niceman/support/distributions/debian.py
@@ -241,8 +241,7 @@ def parse_dpkgquery_line(line):
     )
     if line.startswith('diversion '):
         return None  # we are ignoring diversion details ATM  TODO
-    if ',' in line:
-        lgr.warning("dpkg-query line has multiple packages (%s)" % line)
+
     res = result_re.match(line)
     if res:
         res = res.groupdict()

--- a/niceman/support/distributions/debian.py
+++ b/niceman/support/distributions/debian.py
@@ -237,7 +237,8 @@ def get_apt_release_file_names(url, url_suite):
 
 def parse_dpkgquery_line(line):
     result_re = re.compile(
-        "(?P<name>[^,:]+)(:(?P<architecture>[^,:]+))?(,.*)?: (?P<path>.*)$"
+        "(?P<name>[^,:]+)(:(?P<architecture>[^,:]+))?(?P<pkgs_rest>,.*)?:"
+        " (?P<path>.*)$"
     )
     if line.startswith('diversion '):
         return None  # we are ignoring diversion details ATM  TODO

--- a/niceman/support/distributions/tests/test_debian.py
+++ b/niceman/support/distributions/tests/test_debian.py
@@ -357,13 +357,20 @@ def test_parse_dpkgquery_line():
             ('zlib1g:i386: /lib/i386-linux-gnu/libz.so.1.2.8',
              {'name': 'zlib1g',
               'architecture': 'i386',
-              'path': '/lib/i386-linux-gnu/libz.so.1.2.8'}),
+              'path': '/lib/i386-linux-gnu/libz.so.1.2.8',
+              'pkgs_rest': None}),
             ('fail2ban: /usr/bin/fail2ban-client',
              {'name': 'fail2ban',
-              'path': '/usr/bin/fail2ban-client'}),
+              'path': '/usr/bin/fail2ban-client',
+              'pkgs_rest': None}),
             ('fsl-5.0-eddy-nonfree, fsl-5.0-core: /usr/lib/fsl/5.0',
              {'name': 'fsl-5.0-eddy-nonfree',
-              'path': '/usr/lib/fsl/5.0'}),
+              'path': '/usr/lib/fsl/5.0',
+              'pkgs_rest': ', fsl-5.0-core'}),
+            ('pkg: path,with,commas',
+             {'name': 'pkg',
+              'path': 'path,with,commas',
+              'pkgs_rest': None}),
             ('diversion by dash from: /bin/sh', None)
     ]:
         assert parse_dpkgquery_line(line) == expected

--- a/niceman/support/distributions/tests/test_debian.py
+++ b/niceman/support/distributions/tests/test_debian.py
@@ -12,6 +12,7 @@
 
 from ..debian import DebianReleaseSpec
 from ..debian import get_spec_from_release_file
+from ..debian import parse_dpkgquery_line
 
 from niceman.tests.utils import eq_, assert_is_subset_recur
 
@@ -350,3 +351,15 @@ def test_get_apt_release_file_names():
     assert "/var/lib/apt/lists/_my_repo2_ubuntu_InRelease" in fn
     assert "/var/lib/apt/lists/_my_repo2_ubuntu_Release" in fn
 
+
+def test_parse_dpkgquery_line():
+    assert parse_dpkgquery_line('zlib1g:i386: /lib/i386-linux-gnu/libz.so.1.2.8') == \
+        {'name': 'zlib1g', 'architecture': 'i386', 'path': '/lib/i386-linux-gnu/libz.so.1.2.8'}
+
+    assert parse_dpkgquery_line('fail2ban: /usr/bin/fail2ban-client') == \
+           {'name': 'fail2ban', 'path': '/usr/bin/fail2ban-client'}
+
+    assert parse_dpkgquery_line('fsl-5.0-eddy-nonfree, fsl-5.0-core: /usr/lib/fsl/5.0') == \
+           {'name': 'fsl-5.0-eddy-nonfree', 'path': '/usr/lib/fsl/5.0'}
+
+    assert parse_dpkgquery_line('diversion by dash from: /bin/sh') is None

--- a/niceman/support/distributions/tests/test_debian.py
+++ b/niceman/support/distributions/tests/test_debian.py
@@ -353,13 +353,17 @@ def test_get_apt_release_file_names():
 
 
 def test_parse_dpkgquery_line():
-    assert parse_dpkgquery_line('zlib1g:i386: /lib/i386-linux-gnu/libz.so.1.2.8') == \
-        {'name': 'zlib1g', 'architecture': 'i386', 'path': '/lib/i386-linux-gnu/libz.so.1.2.8'}
-
-    assert parse_dpkgquery_line('fail2ban: /usr/bin/fail2ban-client') == \
-           {'name': 'fail2ban', 'path': '/usr/bin/fail2ban-client'}
-
-    assert parse_dpkgquery_line('fsl-5.0-eddy-nonfree, fsl-5.0-core: /usr/lib/fsl/5.0') == \
-           {'name': 'fsl-5.0-eddy-nonfree', 'path': '/usr/lib/fsl/5.0'}
-
-    assert parse_dpkgquery_line('diversion by dash from: /bin/sh') is None
+    for line, expected in [
+            ('zlib1g:i386: /lib/i386-linux-gnu/libz.so.1.2.8',
+             {'name': 'zlib1g',
+              'architecture': 'i386',
+              'path': '/lib/i386-linux-gnu/libz.so.1.2.8'}),
+            ('fail2ban: /usr/bin/fail2ban-client',
+             {'name': 'fail2ban',
+              'path': '/usr/bin/fail2ban-client'}),
+            ('fsl-5.0-eddy-nonfree, fsl-5.0-core: /usr/lib/fsl/5.0',
+             {'name': 'fsl-5.0-eddy-nonfree',
+              'path': '/usr/lib/fsl/5.0'}),
+            ('diversion by dash from: /bin/sh', None)
+    ]:
+        assert parse_dpkgquery_line(line) == expected


### PR DESCRIPTION
   * Don't warn about  "multiple packages" when the path is a directory because the Debian tracer doesn't handle directories and these warnings flood the screen.
   * Fix "multiple package" test to remove false positives.

Fixes #224.