### PR TITLE
BF+TST: Add 'apt-get update' call to test_ssh_class

### DIFF
--- a/niceman/resource/tests/test_ssh.py
+++ b/niceman/resource/tests/test_ssh.py
@@ -64,6 +64,8 @@ def test_ssh_class(setup_ssh, resource_test_dir):
 
         # Test running commands in a resource.
         resource.connect()
+        command = ['apt-get', 'update']
+        resource.add_command(command)
         command = ['apt-get', 'install', 'bc']
         resource.add_command(command)
         command = ['ls', '/']


### PR DESCRIPTION
The 'apt-get install bc' call is currently failing with "Unable to
locate package bc".

I'm guessing this is because the rastasheep/ubuntu-sshd:14.04
Dockerfile now removes /var/lib/apt/lists.  See aaf4e12 (Added Cleanup
layers for the containers, 2018-05-02) in the rastasheep/ubuntu-sshd
repo.

Fixes #229.