### PR TITLE
BF - Replaced the Docker image tag for the SSH testing container with…

### DIFF
--- a/niceman/resource/tests/test_ssh.py
+++ b/niceman/resource/tests/test_ssh.py
@@ -24,7 +24,7 @@ from niceman.tests.fixtures import get_docker_fixture
 # Note: due to skip_ssh right here, it would skip the entire module with
 # all the tests here if no ssh testing is requested
 setup_ssh = skip_ssh(get_docker_fixture)(
-    'rastasheep/ubuntu-sshd:14.04',
+    'rastasheep/ubuntu-sshd@sha256:918aae46c217701b5516776e0ccc9ebb93abce5ebf3efa4bfd75a842cffc4e04',
     portmaps={
         49000: 22
     },
@@ -64,8 +64,6 @@ def test_ssh_class(setup_ssh, resource_test_dir):
 
         # Test running commands in a resource.
         resource.connect()
-        command = ['apt-get', 'update']
-        resource.add_command(command)
         command = ['apt-get', 'install', 'bc']
         resource.add_command(command)
         command = ['ls', '/']


### PR DESCRIPTION
… its RepoDigest.

This commit removes Kyle's "apt-get update" and replaces the SSH Docker image tag with its RepoDigest hash.