### PR TITLE
BF: git: Get remote branches with 'branch' not 'for-each-ref'

### DIFF
--- a/niceman/distributions/vcs.py
+++ b/niceman/distributions/vcs.py
@@ -362,10 +362,9 @@ class GitRepoShim(GitSVNRepoShim):
             return {}
 
         remote_branches = self._run_git(
-            ["for-each-ref", "--contains", hexsha,
-             # refs/remotes/<remote>/<name> => <remote>/<name>
-             "--format=%(refname:strip=2)",
-             "refs/remotes"]).splitlines()
+            ["branch", "-r", "--contains", hexsha]).splitlines()
+                                               # e.g. "origin/HEAD -> origin/master"
+        remote_branches = [b.strip() for b in remote_branches if " -> " not in b]
 
         if not remote_branches:
             return {}


### PR DESCRIPTION
Use 'git branch' rather than a plumbing command for compatibility with
older gits.  --contains has been available via 'git branch' since
v1.5.4, but the option was only introduced to for-each-ref in v2.7.0.

Fixes #237.