### PR TITLE
BF: dochelpers: Avoid FutureWarning about non-empty regexp match

### DIFF
--- a/niceman/dochelpers.py
+++ b/niceman/dochelpers.py
@@ -145,8 +145,10 @@ def _split_out_parameters(initdoc):
 
 
 __re_params = re.compile('(?:\n\S.*?)+$')
-__re_spliter1 = re.compile('(?:\n|\A)(?=\S)')
+__re_spliter1 = re.compile('\n(?=\S)')
 __re_spliter2 = re.compile('[\n:]')
+
+
 def _parse_parameters(paramdoc):
     """Parse parameters and return list of (name, full_doc_string)
 
@@ -163,6 +165,7 @@ def _parse_parameters(paramdoc):
     lgr.debug('parseParameters: Given "%s", we split into %s' %
               (paramdoc, result))
     return result
+
 
 def get_docstring_split(f):
     """Given a function, break it up into portions


### PR DESCRIPTION
This applies the same fix as DataLad's 8a87175b9.