### PR TITLE
TST: travis: Don't build third-party branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,11 @@ script:
   # Generate documentation and run doctests
   - PYTHONPATH=$PWD make -C docs html doctest
 
+branches:
+  except:
+  - 3rd-repronimed
+  - 3rd
+
 after_success:
   - codecov
 


### PR DESCRIPTION
As expected, the tests fail on these branches.