### PR TITLE
NF: Add initial support for "installing" Git repositories 

### DIFF
--- a/niceman/distributions/tests/test_vcs.py
+++ b/niceman/distributions/tests/test_vcs.py
@@ -211,7 +211,7 @@ def test_svn(svn_repo):
     uuid = open(uuid_file).readlines()[0].strip()
     tracer = VCSTracer()
     assert_distributions(
-        tracer.identify_distributions([svn_file]), 
+        tracer.identify_distributions([svn_file]),
         expected_length=1,
         expected_subset={'name': 'svn'})
     svn_repo = list(tracer.identify_distributions([svn_file]))[0][0].packages[0]
@@ -220,6 +220,7 @@ def test_svn(svn_repo):
     assert svn_repo.revision == 1
     assert svn_repo.identifier == svn_repo.uuid
     assert svn_repo.commit == svn_repo.revision
+
 
 def test_empty_svn(svn_repo_empty):
     (svn_repo_root, checked_out_dir) = svn_repo_empty

--- a/niceman/distributions/tests/test_vcs.py
+++ b/niceman/distributions/tests/test_vcs.py
@@ -7,19 +7,29 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 import os
+import os.path as op
 
 import attr
+import copy
+import logging
+import pytest
 
 from niceman.cmd import GitRunner
 from niceman.distributions.vcs import VCSTracer
+from niceman.support.exceptions import CommandError
 from niceman.utils import chpwd
+from niceman.utils import swallow_logs
 from niceman.tests.utils import assert_is_subset_recur
+from niceman.tests.utils import create_tree
+from niceman.tests.utils import with_tree
 from niceman.tests.fixtures import git_repo_fixture, svn_repo_fixture
-
+from niceman.distributions.vcs import GitDistribution
+from niceman.distributions.vcs import GitRepo
 
 git_repo_empty = git_repo_fixture(kind="empty")
 git_repo = git_repo_fixture()
 git_repo_pair = git_repo_fixture(kind="pair")
+git_repo_pair_module = git_repo_fixture(kind="pair", scope="module")
 
 svn_repo_empty = svn_repo_fixture(kind='empty')
 svn_repo = svn_repo_fixture()
@@ -202,6 +212,229 @@ def test_git_repo_remotes(git_repo_pair):
     paths = [os.path.join(repo_remote, "foo")]
     dists_remote = list(tracer.identify_distributions(paths))
     assert not dists_remote[0][0].packages[0].remotes.values()
+
+
+def test_git_install_no_remote():
+    dist = GitDistribution(name="git",
+                           packages=[GitRepo(path="/tmp/shouldnt/matter")])
+
+    with swallow_logs(new_level=logging.WARNING) as log:
+        dist.initiate()
+        dist.install_packages()
+        assert "No remote known" in log.out
+
+
+@with_tree(tree={"foo": ""})
+def test_git_install_skip_existing_nongit(path=None):
+    with swallow_logs(new_level=logging.WARNING) as log:
+        dist_dir = GitDistribution(
+            name="git",
+            packages=[
+                GitRepo(path=path,
+                        remotes={"origin": {"url": "doesnt-matter",
+                                            "contains": True}})])
+        dist_dir.install_packages()
+        assert "not a Git repository; skipping" in log.out
+
+    with swallow_logs(new_level=logging.WARNING) as log:
+        dist_dir = GitDistribution(
+            name="git",
+            packages=[
+                GitRepo(path=op.join(path, "foo"),
+                        remotes={"origin": {"url": "doesnt-matter",
+                                            "contains": True}})])
+        dist_dir.install_packages()
+        assert "not a directory; skipping" in log.out
+
+
+def test_git_install_skip_different_git(git_repo):
+    with swallow_logs(new_level=logging.WARNING) as log:
+        dist_dir = GitDistribution(
+            name="git",
+            packages=[
+                GitRepo(path=git_repo,
+                        root_hexsha="definitely doesn't match",
+                        remotes={"origin": {"url": "doesnt-matter",
+                                            "contains": True}})])
+        dist_dir.install_packages()
+        assert "doesn't match expected hexsha; skipping" in log.out
+
+
+@pytest.fixture(scope="module")
+def traced_repo(git_repo_pair_module):
+    """Return a Git repo pair and the traced GitDistribution for the local repo.
+    """
+    repo_local, repo_remote = git_repo_pair_module
+
+    tracer = VCSTracer()
+    dists = list(tracer.identify_distributions([op.join(repo_local, "foo")]))
+    git_dist = dists[0][0]
+    assert len(git_dist.packages) == 1
+
+    return {"repo_local": repo_local,
+            "repo_remote": repo_remote,
+            "git_dist": git_dist}
+
+
+@pytest.fixture(scope="function")
+def traced_repo_copy(traced_repo):
+    return copy.deepcopy(traced_repo)
+
+
+def install(git_dist, dest, check=False):
+    """Helper to install GitDistribution `git_dist` to `dest`.
+
+    If `check`, trace the installed repository and run a basic comparison in
+    the GitRepo objects.
+    """
+    tracer = VCSTracer()
+    git_dist.install_packages()
+
+    if check:
+        dists_installed = list(
+            tracer.identify_distributions([op.join(dest, "foo")]))
+        git_dist_installed = dists_installed[0][0]
+        assert len(git_dist_installed.packages) == 1
+        git_pkg = git_dist.packages[0]
+        git_pkg_installed = git_dist_installed.packages[0]
+
+        for att in ["hexsha", "root_hexsha", "tracked_remote", "remotes"]:
+            assert getattr(git_pkg, att) == getattr(git_pkg_installed, att)
+
+
+def current_hexsha(runner):
+    return runner(["git", "rev-parse", "HEAD"])[0].strip()
+
+
+def current_branch(runner):
+    try:
+        out = runner(["git", "symbolic-ref", "--short", "HEAD"],
+                     expect_fail=True)
+    except CommandError:
+        return
+    return out[0].strip()
+
+
+@pytest.mark.integration
+def test_git_install(traced_repo_copy, tmpdir):
+    git_dist = traced_repo_copy["git_dist"]
+    git_pkg = git_dist.packages[0]
+    tmpdir = str(tmpdir)
+
+    # Install package to a new location.
+    install_dir = op.join(tmpdir, "installed")
+    git_pkg.path = install_dir
+
+    install(git_dist, install_dir, check=True)
+    # Installing a second time works if the root hexsha's match.
+    install(git_dist, install_dir, check=True)
+
+    runner = GitRunner(cwd=install_dir)
+
+    # We don't try to change the state of the repository if it's dirty.
+    runner(["git", "reset", "--hard", "HEAD^"])
+    hexsha_existing = current_hexsha(runner)
+    create_tree(install_dir, {"dirt": "dirt"})
+    with swallow_logs(new_level=logging.WARNING) as log:
+        install(git_dist, install_dir)
+        assert "repository is dirty" in log.out
+    assert current_hexsha(runner) == hexsha_existing
+
+    # We end up on the intended commit (detached) if the existing installation
+    # repo is clean.
+    os.remove(op.join(install_dir, "dirt"))
+    install(git_dist, install_dir)
+    assert current_hexsha(runner) == git_pkg.hexsha
+    assert not current_branch(runner)
+
+
+@pytest.mark.integration
+def test_git_install_detached(traced_repo_copy, tmpdir):
+    git_dist = traced_repo_copy["git_dist"]
+    git_pkg = git_dist.packages[0]
+    tmpdir = str(tmpdir)
+
+    # Install package to a new location.
+    install_dir = op.join(tmpdir, "installed")
+    git_pkg.path = install_dir
+    runner = GitRunner(cwd=install_dir)
+    install(git_dist, install_dir)
+
+    # We detach if there is no recorded branch.
+    git_pkg.branch = None
+    runner(["git", "checkout", "master"])
+    install(git_dist, install_dir)
+    assert current_hexsha(runner) == git_pkg.hexsha
+    assert not current_branch(runner)
+
+
+@pytest.mark.integration
+def test_git_install_hexsha_not_found(traced_repo_copy, tmpdir):
+    git_dist = traced_repo_copy["git_dist"]
+    git_pkg = git_dist.packages[0]
+    tmpdir = str(tmpdir)
+
+    # Install package to a new location.
+    install_dir = op.join(tmpdir, "installed")
+    git_pkg.path = install_dir
+    install(git_dist, install_dir)
+
+    # No existing hexsha.
+    git_pkg.hexsha = "0" * 40
+    with swallow_logs(new_level=logging.WARNING) as log:
+        install(git_dist, install_dir)
+        assert "expected hexsha wasn't found" in log.out
+
+
+@pytest.mark.integration
+def test_git_install_checkout(traced_repo_copy, tmpdir):
+    git_dist = traced_repo_copy["git_dist"]
+    git_pkg = git_dist.packages[0]
+    tmpdir = str(tmpdir)
+
+    install_dir = op.join(tmpdir, "installed")
+    runner = GitRunner(cwd=install_dir)
+
+    # Installing to a non-existing location will be more aggressive, creating a
+    # new branch at the recorded hexsha rather than just detaching there.
+    git_pkg.path = install_dir
+    git_pkg.branch = "other"
+    install(git_dist, install_dir, check=True)
+    assert current_branch(runner) == "other"
+
+    # If the recorded branch is in the existing installation repo and has the
+    # same hexsha, we check it out.
+    runner(["git", "checkout", "master"])
+    runner(["git", "branch", "--force", "other", git_pkg.hexsha])
+    install(git_dist, install_dir)
+    assert current_hexsha(runner) == git_pkg.hexsha
+    assert current_branch(runner) == "other"
+    # Otherwise, we detach.
+    runner(["git", "checkout", "master"])
+    runner(["git", "branch", "--force", "other", git_pkg.hexsha + "^"])
+    install(git_dist, install_dir)
+    assert current_hexsha(runner) == git_pkg.hexsha
+    assert not current_branch(runner)
+
+
+@pytest.mark.integration
+def test_git_install_add_remotes(traced_repo_copy, tmpdir):
+    git_dist = traced_repo_copy["git_dist"]
+    git_pkg = git_dist.packages[0]
+    tmpdir = str(tmpdir)
+
+    install_dir = op.join(tmpdir, "installed")
+    runner = GitRunner(cwd=install_dir)
+
+    git_pkg.path = install_dir
+    git_pkg.tracked_remote = "foo"
+    url = git_pkg.remotes.popitem()[1]["url"]
+    git_pkg.remotes = {"foo": {"contains": False, "url": url},
+                       "bar": {"contains": True, "url": url}}
+    install(git_dist, install_dir)
+    installed_remotes = runner(["git", "remote"],
+                               cwd=install_dir)[0].splitlines()
+    assert set(installed_remotes) == {"foo", "bar"}
 
 
 def test_svn(svn_repo):

--- a/niceman/distributions/tests/test_vcs.py
+++ b/niceman/distributions/tests/test_vcs.py
@@ -266,6 +266,9 @@ def traced_repo(git_repo_pair_module):
     """
     repo_local, repo_remote = git_repo_pair_module
 
+    runner = GitRunner(cwd=repo_local)
+    runner(["git", "remote", "add", "dummy-remote", "nowhere"])
+
     tracer = VCSTracer()
     dists = list(tracer.identify_distributions([op.join(repo_local, "foo")]))
     git_dist = dists[0][0]

--- a/niceman/distributions/tests/test_vcs.py
+++ b/niceman/distributions/tests/test_vcs.py
@@ -429,7 +429,7 @@ def test_git_install_add_remotes(traced_repo_copy, tmpdir):
     git_pkg.path = install_dir
     git_pkg.tracked_remote = "foo"
     url = git_pkg.remotes.popitem()[1]["url"]
-    git_pkg.remotes = {"foo": {"contains": False, "url": url},
+    git_pkg.remotes = {"foo": {"url": url},
                        "bar": {"contains": True, "url": url}}
     install(git_dist, install_dir)
     installed_remotes = runner(["git", "remote"],

--- a/niceman/distributions/vcs.py
+++ b/niceman/distributions/vcs.py
@@ -162,8 +162,12 @@ class GitDistribution(VCSDistribution):
             current_remotes = set(shim._run_git(["remote"]).splitlines())
             for remote, remote_info in repo.remotes.items():
                 if remote not in current_remotes:
-                    shim._run_git(
-                        ["remote", "add", "-f", remote, remote_info["url"]])
+                    try:
+                        shim._run_git(["remote", "add", "-f",
+                                       remote, remote_info["url"]])
+                    except CommandError:
+                        lgr.warning("Failed to fetch remote %s at %s",
+                                    remote, remote_info["url"])
 
         if not shim.has_revision(repo.hexsha):
             lgr.warning("Set up '%s', but the expected hexsha wasn't found",

--- a/niceman/distributions/vcs.py
+++ b/niceman/distributions/vcs.py
@@ -127,7 +127,7 @@ class GitDistribution(VCSDistribution):
             self._install_repo(session, repo)
 
     def _install_repo(self, session, repo):
-        sources = {k: v for k, v in repo.remotes.items() if v["contains"]}
+        sources = {k: v for k, v in repo.remotes.items() if v.get("contains")}
         if not sources:
             lgr.warning("No remote known for '%s'; skipping", repo.path)
             return

--- a/niceman/distributions/vcs.py
+++ b/niceman/distributions/vcs.py
@@ -83,7 +83,7 @@ class VCSRepo(SpecObject):
         try:
             return getattr(self, self._identifier_attribute)
         except AttributeError:
-            # raised if _identifier_attribute is not defined, but this means 
+            # raised if _identifier_attribute is not defined, but this means
             # (to the caller) that identifier is not defined
             msg = "%s instance has no attribute 'identifier'" % self.__class__
             raise AttributeError(msg)
@@ -150,11 +150,11 @@ SVNRepo._distribution = SVNDistribution
 # We use unified VCSTracer but it needs per-VCS specific handling/
 # VCS objects are not created to worry/carry the session information
 # so we have per-VCS shim objects which would be tracer helpers
-# 
+#
 class GitSVNRepoShim(object):
     _ls_files_command = None  # just need to define in subclass
     _ls_files_filter = None
-    
+
     _vcs_class = None  # associated VCS class
 
     def __init__(self, path, session):
@@ -215,10 +215,10 @@ class GitSVNRepoShim(object):
 # Name must be   TYPERepo since used later in the code
 # As an overkill might want some metaclass to look after that ;-)
 class SVNRepoShim(GitSVNRepoShim):
-    
+
     _vcs_class = SVNRepo
     _vcs_distribution_class = SVNDistribution
-    
+
     @property
     def _ls_files_command(self):
         # tricky -- we need to locate wc.db somewhere upstairs, and filter out paths
@@ -290,8 +290,8 @@ class SVNRepoShim(GitSVNRepoShim):
 
     @property
     def revision(self):
-        # svn info doesn't give the current revision 
-        # (see http://svnbook.red-bean.com/en/1.7/svn.tour.history.html) 
+        # svn info doesn't give the current revision
+        # (see http://svnbook.red-bean.com/en/1.7/svn.tour.history.html)
         # so we need to run svn log
         if not hasattr(self, '_revision'):
             runner = Runner()
@@ -375,7 +375,7 @@ class GitRepoShim(GitSVNRepoShim):
         except CommandError:
             # might still be the first yet to be committed state in the branch
             return None
-        
+
     @property
     def root_hexsha(self):
         try:
@@ -384,7 +384,7 @@ class GitRepoShim(GitSVNRepoShim):
         except CommandError:
             # might still be the first yet to be committed state in the branch
             return None
-        
+
     @property
     def describe(self):
         """Let's use git describe"""
@@ -488,7 +488,7 @@ class VCSTracer(DistributionTracer):
         # dictionary to contain per each inspected/known directory a VCS
         # instance it belongs to
         self._known_repos = {}
-        
+
     def identify_distributions(self, files):
         repos, remaining_files = self.identify_packages_from_files(files)
         pkgs_per_distr = defaultdict(list)


### PR DESCRIPTION
This adds basic support for instantiating Git repositories listed in a
GitDistribution object.  If a repository isn't present, we clone it
from one of the recorded sources.  Otherwise, if the recorded revision
isn't present, we fetch a remote that is marked as containing that
revision.  GitDistribution.install_packages' main goal is to check
out the same revision, but it also sets up the recorded remotes and
checks outs the recorded branch if possible.

~Right now the tests only cover the simpler cases.~

---

- [x] extend test coverage
