### PR TITLE
BF: conda install: Work with packages and channels as SpecObject's

### DIFF
--- a/niceman/distributions/conda.py
+++ b/niceman/distributions/conda.py
@@ -251,16 +251,17 @@ class CondaDistribution(Distribution):
         name = os.path.basename(os.path.normpath(env.path))
         d["name"] = name
         # Collect channels
-        d["channels"] = [c["name"] for c in env.channels]
+        d["channels"] = [c.name for c in env.channels]
         # Collect packages (dependencies) with no installer
-        d["dependencies"] = [CondaDistribution.format_conda_package(**p)
-                             for p in env.packages
-                             if p.get("installer") is None]
+        d["dependencies"] = [
+            CondaDistribution.format_conda_package(p.name, p.version, p.build)
+            for p in env.packages
+            if p.installer is None]
         #            p.get("name"), p.get("version"), p.get("build"))
         # Collect pip-installed dependencies
-        pip_deps = [CondaDistribution.format_pip_package(**p)
+        pip_deps = [CondaDistribution.format_pip_package(p.name, p.version)
                     for p in env.packages
-                    if p.get("installer") is "pip"]
+                    if p.installer is "pip"]
         if (pip_deps):
             d["dependencies"].append({"pip": pip_deps})
         # Add the prefix

--- a/niceman/distributions/tests/test_conda.py
+++ b/niceman/distributions/tests/test_conda.py
@@ -28,7 +28,8 @@ from niceman.tests.utils import skip_if_no_network, assert_is_subset_recur
 import json
 
 from niceman.distributions.conda import CondaTracer, CondaDistribution, \
-    CondaEnvironment, get_conda_platform_from_python, get_miniconda_url
+    CondaEnvironment, CondaPackage, CondaChannel, \
+    get_conda_platform_from_python, get_miniconda_url
 
 
 def test_get_conda_platform_from_python():
@@ -68,32 +69,31 @@ def test_create_conda_export():
     env = CondaEnvironment(
         name="mytest",
         path="/home/butch/.cache/niceman/conda_test/miniconda/envs/mytest",
-        packages=[{
-            "name": "xz",
-            "installer": None,
-            "version": "5.2.3",
-            "build": "0",
-            "channel_name": "conda-forge",
-            "md5": "f4e0d30b3caf631be7973cba1cf6f601",
-            "size": "874292",
-            "url": "https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.3-0.tar.bz2",
-            "files": ["bin/xz", ],
-        }, {
-            "name": "rpaths",
-            "installer": "pip",
-            "version": "0.13",
-            "build": None,
-            "channel_name": None,
-            "md5": None,
-            "size": None,
-            "url": None,
-            "files": ["lib/python2.7/site-packages/rpaths.py", ],
-        }, ],
-        channels=[{
-            "name": "conda-forge",
-            "url": "https://conda.anaconda.org/conda-forge/linux-64",
-        }, ],
-    )
+        packages=[
+            CondaPackage(
+                name="xz",
+                installer=None,
+                version="5.2.3",
+                build="0",
+                channel_name="conda-forge",
+                md5="f4e0d30b3caf631be7973cba1cf6f601",
+                size="874292",
+                url="https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.3-0.tar.bz2",
+                files=["bin/xz"]),
+            CondaPackage(
+                name="rpaths",
+                installer="pip",
+                version="0.13",
+                build=None,
+                channel_name=None,
+                md5=None,
+                size=None,
+                url=None,
+                files=["lib/python2.7/site-packages/rpaths.py"])],
+        channels=[
+            CondaChannel(
+                name="conda-forge",
+                url="https://conda.anaconda.org/conda-forge/linux-64")])
     out = {"name": "mytest",
            "channels": ["conda-forge"],
            "dependencies": ["xz=5.2.3=0",
@@ -119,85 +119,82 @@ def test_conda_init_install_and_detect():
             CondaEnvironment(
                 name="root",
                 path=test_dir,
-                packages=[{
-                    "name": "conda",
-                    "installer": None,
-                    "version": "4.3.31",
-                    "build": None,
-                    "channel_name": None,
-                    "md5": None,
-                    "size": None,
-                    "url": None,
-                    "files": None,
-                },{
-                    "name": "pip",
-                    "installer": None,
-                    "version": "9.0.1",
-                    "build": None,
-                    "channel_name": None,
-                    "md5": None,
-                    "size": None,
-                    "url": None,
-                    "files": None,
-                }, {
-                    "name": "pytest",
-                    "installer": "pip",
-                    "version": "3.4.0",
-                    "build": None,
-                    "channel_name": None,
-                    "md5": None,
-                    "size": None,
-                    "url": None,
-                    "files": None,
-                }, ],
-                channels=[{
-                    "name": "conda-forge",
-                    "url": "https://conda.anaconda.org/conda-forge/linux-64",
-                }, {
-                    "name": "defaults",
-                    "url": "https://repo.continuum.io/pkgs/main/linux-64",
-                }, ],
-            ),
+                packages=[
+                    CondaPackage(
+                        name="conda",
+                        installer=None,
+                        version="4.3.31",
+                        build=None,
+                        channel_name=None,
+                        md5=None,
+                        size=None,
+                        url=None,
+                        files=None),
+                    CondaPackage(
+                        name="pip",
+                        installer=None,
+                        version="9.0.1",
+                        build=None,
+                        channel_name=None,
+                        md5=None,
+                        size=None,
+                        url=None,
+                        files=None),
+                    CondaPackage(
+                        name="pytest",
+                        installer="pip",
+                        version="3.4.0",
+                        build=None,
+                        channel_name=None,
+                        md5=None,
+                        size=None,
+                        url=None,
+                        files=None)],
+                channels=[
+                    CondaChannel(
+                        name="conda-forge",
+                        url="https://conda.anaconda.org/conda-forge/linux-64"),
+                    CondaChannel(
+                        name="defaults",
+                        url="https://repo.continuum.io/pkgs/main/linux-64")]),
             CondaEnvironment(
                 name="mytest",
                 path=os.path.join(test_dir, "envs/mytest"),
-                packages=[{
-                    "name": "pip",
-                    "installer": None,
-                    "version": "9.0.1",
-                    "build": None,
-                    "channel_name": None,
-                    "md5": None,
-                    "size": None,
-                    "url": None,
-                    "files": None,
-                }, {
-                    "name": "xz",
-                    "installer": None,
-                    "version": "5.2.3",
-                    "build": "0",
-                    "channel_name": "conda-forge",
-                    "md5": "f4e0d30b3caf631be7973cba1cf6f601",
-                    "size": "874292",
-                    "url": "https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.3-0.tar.bz2",
-                    "files": ["bin/xz", ],
-                }, {
-                    "name": "rpaths",
-                    "installer": "pip",
-                    "version": "0.13",
-                    "build": None,
-                    "channel_name": None,
-                    "md5": None,
-                    "size": None,
-                    "url": None,
-                    "files": ["lib/python2.7/site-packages/rpaths.py", ],
-                }, ],
-                channels=[{
-                    "name": "conda-forge",
-                    "url": "https://conda.anaconda.org/conda-forge/linux-64",
-                }, ],
-            ),
-        ])
+                packages=[
+                    CondaPackage(
+                        name="pip",
+                        installer=None,
+                        version="9.0.1",
+                        build=None,
+                        channel_name=None,
+                        md5=None,
+                        size=None,
+                        url=None,
+                        files=None),
+                    CondaPackage(
+                        name="xz",
+                        installer=None,
+                        version="5.2.3",
+                        build="0",
+                        channel_name="conda-forge",
+                        md5="f4e0d30b3caf631be7973cba1cf6f601",
+                        size="874292",
+                        url="https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.3-0.tar.bz2",
+                        files=["bin/xz", ]),
+                    CondaPackage(
+                        name="rpaths",
+                        installer="pip",
+                        version="0.13",
+                        build=None,
+                        channel_name=None,
+                        md5=None,
+                        size=None,
+                        url=None,
+                        files=["lib/python2.7/site-packages/rpaths.py"])],
+                channels=[
+                    CondaChannel(
+                        name="conda-forge",
+                        url="https://conda.anaconda.org/conda-forge/linux-64")])])
     # First install the environment in /tmp/niceman_conda/miniconda
     dist.initiate(None)
     dist.install_packages()
@@ -257,6 +254,11 @@ def test_conda_init_install_and_detect():
         for pkg in envs.packages:
             if pkg.name == "pip":
                 assert pkg.installer is None
+
+    # Smoke test to make sure install_packages doesn't choke on the format that
+    # is actually returned by the tracer.
+    distributions.initiate(None)
+    distributions.install_packages()
 
 
 def test_get_conda_env_export_exceptions():


### PR DESCRIPTION
Conda's installation code originally handled packages and channels as
dicts because NicemanProvenance stopped converting dicts to objects at
that depth.  This is no longer the case as of 3b8a9884 (RF+BF: read
spec recursively, 2018-05-07).