### PR TITLE
TST: docker: Don't assume that tags map stably to image IDs

### DIFF
--- a/niceman/distributions/tests/test_docker.py
+++ b/niceman/distributions/tests/test_docker.py
@@ -38,6 +38,13 @@ def test_docker_trace():
     assert dist.images[0].created == '2018-01-09T21:10:38.538173323Z'
     assert 'non-existent-image' in remaining_files
 
+
+@skip_if_no_network
+@skip_if_no_docker_engine
+def test_docker_trace_local_image():
+    client = docker.Client()
+    client.pull('alpine:3.6')
+    tracer = DockerTracer()
     # Test tracing a local image not saved in a repository
     container = client.create_container(image='alpine:3.6',
         command='echo foo > test.txt')

--- a/niceman/distributions/tests/test_docker.py
+++ b/niceman/distributions/tests/test_docker.py
@@ -20,7 +20,7 @@ from ...tests.utils import skip_if_no_docker_engine, skip_if_no_network
 
 @skip_if_no_network
 @skip_if_no_docker_engine
-def test_docker_trace():
+def test_docker_trace_tag():
     client = docker.Client()
     client.pull('alpine:3.6')
 
@@ -29,14 +29,33 @@ def test_docker_trace():
     files = ['alpine:3.6', 'non-existent-image']
     dist, remaining_files = next(tracer.identify_distributions(files))
     assert dist.name == 'docker'
-    assert dist.images[0].id == 'sha256:77144d8c6bdce9b97b6d5a900f1ab85da' + \
-        '325fe8a0d1b0ba0bbff2609befa2dda'
     assert dist.images[0].architecture == 'amd64'
     assert dist.images[0].operating_system == 'linux'
     assert dist.images[0].repo_digests[0].startswith('alpine@sha256')
     assert dist.images[0].repo_tags[0] == 'alpine:3.6'
-    assert dist.images[0].created == '2018-01-09T21:10:38.538173323Z'
     assert 'non-existent-image' in remaining_files
+
+
+@skip_if_no_network
+@skip_if_no_docker_engine
+def test_docker_trace_id():
+    client = docker.Client()
+    repo_id = 'sha256:f625bd3ff910ad2c68a405ccc5e294d2714fc8cfe7b5d80a8331c72ad5cc7630'
+    name = 'alpine@' + repo_id
+    client.pull(name)
+
+    tracer = DockerTracer()
+
+    files = [name]
+    dist, remaining_files = next(tracer.identify_distributions(files))
+    assert dist.name == 'docker'
+    assert dist.images[0].id == 'sha256:77144d8c6bdce9b97b6d5a900f1ab85da' + \
+        '325fe8a0d1b0ba0bbff2609befa2dda'
+    assert dist.images[0].architecture == 'amd64'
+    assert dist.images[0].operating_system == 'linux'
+    assert dist.images[0].id == 'sha256:77144d8c6bdce9b97b6d5a900f1ab85da' + \
+        '325fe8a0d1b0ba0bbff2609befa2dda'
+    assert dist.images[0].created == '2018-01-09T21:10:38.538173323Z'
 
 
 @skip_if_no_network
@@ -75,9 +94,6 @@ def test_docker_distribution():
     except docker.errors.NotFound:
         pass
 
-    # Install alpine:3.6 image from hub
-    client.pull('alpine:3.6')
-
     # Test tracing valid images
     dist = DockerDistribution('docker')
     dist.images = [
@@ -103,11 +119,15 @@ def test_docker_distribution():
         '78584c3c6aff915272b231593f6f98'
     assert 'alpine@sha256:9148d069e50eee519ec45e5683e56a1c217b61a52ed90eb' + \
         '77bdce674cc212f1e' in alpine_3_5['RepoDigests']
-    assert 'alpine:3.5' in alpine_3_5['RepoTags']
     alpine_3_6 = client.inspect_image(dist.images[1].id)
     assert alpine_3_6['Id'] == 'sha256:77144d8c6bdce9b97b6d5a900f1ab85da3' + \
         '25fe8a0d1b0ba0bbff2609befa2dda'
-    assert 'alpine:3.6' in alpine_3_6['RepoTags']
+
+    # FIXME: Tag checks are disabled to avoid errors from unstable IDs.  We
+    # should switch to using images that under our control.  See gh-254.
+    #
+    # assert 'alpine:3.5' in alpine_3_5['RepoTags']
+    # assert 'alpine:3.6' in alpine_3_6['RepoTags']
 
     # Clean up docker engine
     client.remove_image(dist.images[0].id)

--- a/niceman/distributions/tests/test_docker.py
+++ b/niceman/distributions/tests/test_docker.py
@@ -26,7 +26,7 @@ def test_docker_trace():
 
     tracer = DockerTracer()
 
-    files = ['alpine:3.6', 'non-existant-image']
+    files = ['alpine:3.6', 'non-existent-image']
     dist, remaining_files = next(tracer.identify_distributions(files))
     assert dist.name == 'docker'
     assert dist.images[0].id == 'sha256:77144d8c6bdce9b97b6d5a900f1ab85da' + \
@@ -36,7 +36,7 @@ def test_docker_trace():
     assert dist.images[0].repo_digests[0].startswith('alpine@sha256')
     assert dist.images[0].repo_tags[0] == 'alpine:3.6'
     assert dist.images[0].created == '2018-01-09T21:10:38.538173323Z'
-    assert 'non-existant-image' in remaining_files
+    assert 'non-existent-image' in remaining_files
 
     # Test tracing a local image not saved in a repository
     container = client.create_container(image='alpine:3.6',
@@ -106,7 +106,7 @@ def test_docker_distribution():
     client.remove_image(dist.images[0].id)
     client.remove_image(dist.images[1].id)
 
-    # Test installing a non-existant image
+    # Test installing a non-existent image
     dist.images = [
         DockerImage(
             'sha256:000000000000000000000000000000000000000000000000000000',


### PR DESCRIPTION
As recent test failures show (gh-254), this isn't the case.

Break apart test_docker_trace into two tests.  The first pulls by a
tag and traces the image, making no assumptions about the actual IDs.
The second pulls by the digest so that we can make assertions with
known IDs.

Also, temporarily disable assertions about the tags of installed
"packages" because these repo tags won't be present if another local
image is already has with that tag (e.g., an updated alpine@3.6).

This approach should eliminate failures due to changing IDs as long as
the untagged repo digests remain available on DockerHub.  However, we
should eventually generate/upload our own test images so that we can
control the image tags.

Re: #203
Closes #254.