### PR TITLE
BF+TST: vcs: Fix flaky test_git_install_add_remotes

### DIFF
--- a/niceman/distributions/tests/test_vcs.py
+++ b/niceman/distributions/tests/test_vcs.py
@@ -431,7 +431,7 @@ def test_git_install_add_remotes(traced_repo_copy, tmpdir):
 
     git_pkg.path = install_dir
     git_pkg.tracked_remote = "foo"
-    url = git_pkg.remotes.popitem()[1]["url"]
+    url = git_pkg.remotes["origin"]["url"]
     git_pkg.remotes = {"foo": {"url": url},
                        "bar": {"contains": True, "url": url}}
     install(git_dist, install_dir)


### PR DESCRIPTION
When this test was originally added, there was only one remote, so it
was deterministic.  But a following commit added a second remote with
a dead url, and we can't use that one to clone the repo.

Fixes #259.