### PR TITLE
NF: venv: Add basic support for installation 

### DIFF
--- a/niceman/distributions/tests/test_venv.py
+++ b/niceman/distributions/tests/test_venv.py
@@ -7,16 +7,22 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 import os
+import os.path as op
 import sys
 
 from appdirs import AppDirs
 import attr
 import pytest
+import logging
 
 from niceman.cmd import Runner
 from niceman.utils import chpwd
 from niceman.tests.utils import create_pymodule
 from niceman.tests.utils import skip_if_no_network, assert_is_subset_recur
+from niceman.tests.utils import swallow_logs
+from niceman.distributions.venv import VenvDistribution
+from niceman.distributions.venv import VenvEnvironment
+from niceman.distributions.venv import VenvPackage
 from niceman.distributions.venv import VenvTracer
 
 PY_VERSION = "python{v.major}.{v.minor}".format(v=sys.version_info)
@@ -80,3 +86,67 @@ def test_venv_identify_distributions(venv_test_dir):
                    {"packages": [{"files": [paths[1]], "name": "attrs",
                                   "editable": False}]}]}
         assert_is_subset_recur(expect, attr.asdict(distributions), [dict, list])
+
+
+@pytest.mark.integration
+def test_venv_install(venv_test_dir, tmpdir):
+    tmpdir = str(tmpdir)
+    paths = ["lib/" + PY_VERSION + "/site-packages/yaml/parser.py",
+             "lib/" + PY_VERSION + "/site-packages/attr/filters.py"]
+
+    tracer = VenvTracer()
+    dists = list(
+        tracer.identify_distributions(
+            [op.join(venv_test_dir, "venv0", paths[0]),
+             op.join(venv_test_dir, "venv1", paths[1])]))
+    assert len(dists) == 1
+    dist = dists[0][0]
+
+    assert len(dist.environments) == 2
+    for idx in range(2):
+        dist.environments[idx].path = op.join(tmpdir, "venv{}".format(idx))
+
+    dist.initiate(None)
+    dist.install_packages()
+
+    dists_installed = list(
+        tracer.identify_distributions(
+            [op.join(tmpdir, "venv0", paths[0]),
+             op.join(tmpdir, "venv1", paths[1])]))
+    assert len(dists_installed) == 1
+    dist_installed = dists_installed[0][0]
+
+    expect = {"environments":
+              [{"packages": [{"name": "PyYAML",
+                              "editable": False}]},
+               {"packages": [{"name": "attrs",
+                              "editable": False}]}]}
+    assert_is_subset_recur(expect, attr.asdict(dist_installed), [dict, list])
+
+    # We don't yet handle editable packages.
+    assert any([p.name == "nmtest"
+                for e in dist.environments
+                for p in e.packages])
+    assert not any([p.name == "nmtest"
+                    for e in dist_installed.environments
+                    for p in e.packages])
+
+
+def test_venv_install_noop():
+    dist = VenvDistribution(
+        name="venv",
+        path="/tmp/doesnt/matter/",
+        venv_version="15.1.0",
+        environments=[
+            VenvEnvironment(
+                path="/tmp/doesnt/matter/venv",
+                python_version="3.7",
+                packages=[
+                    VenvPackage(
+                        name="imeditable",
+                        version="0.1.0",
+                        editable=True,
+                        local=True)])])
+    with swallow_logs(new_level=logging.INFO) as log:
+        dist.install_packages()
+        assert "No local, non-editable packages found" in log.out

--- a/niceman/distributions/tests/test_venv.py
+++ b/niceman/distributions/tests/test_venv.py
@@ -46,7 +46,6 @@ def venv_test_dir():
 
 
 def test_venv_identify_distributions(venv_test_dir):
-    pydir = "python{v.major}.{v.minor}".format(v=sys.version_info)
     paths = ["lib/" + PY_VERSION + "/site-packages/yaml/parser.py",
              "lib/" + PY_VERSION + "/site-packages/attr/filters.py"]
 

--- a/niceman/distributions/tests/test_venv.py
+++ b/niceman/distributions/tests/test_venv.py
@@ -45,6 +45,7 @@ def venv_test_dir():
     return test_dir
 
 
+@pytest.mark.integration
 def test_venv_identify_distributions(venv_test_dir):
     paths = ["lib/" + PY_VERSION + "/site-packages/yaml/parser.py",
              "lib/" + PY_VERSION + "/site-packages/attr/filters.py"]

--- a/niceman/distributions/venv.py
+++ b/niceman/distributions/venv.py
@@ -17,8 +17,12 @@ import attr
 from six import iteritems
 from niceman.distributions import Distribution
 from niceman.distributions import piputils
+from niceman.dochelpers import borrowdoc
 from niceman.dochelpers import exc_str
 from niceman.utils import attrib, PathRoot, is_subpath
+from niceman.utils import execute_command_batch
+from niceman.utils import parse_semantic_version
+from niceman.resource.session import get_local_session
 
 from .base import DistributionTracer
 from .base import Package
@@ -56,8 +60,37 @@ class VenvDistribution(Distribution):
     def initiate(self, _):
         return
 
+    @borrowdoc(Distribution)
     def install_packages(self, session=None):
-        raise NotImplementedError
+        session = session or get_local_session()
+        for env in self.environments:
+            # TODO: Deal with system and editable packages.
+            to_install = ["{p.name}=={p.version}".format(p=p)
+                          for p in env.packages
+                          if p.local and not p.editable]
+            if not to_install:
+                lgr.info("No local, non-editable packages found")
+                continue
+
+            # TODO: Right now we just use the python to invoke "virtualenv
+            # --python=..." when the directory doesn't exist, but we should
+            # eventually use the yet-to-exist "satisfies" functionality to
+            # check whether an existing virtual environment has the right
+            # python (and maybe other things).
+            pyver = "{v.major}.{v.minor}".format(
+                v=parse_semantic_version(env.python_version))
+
+            if not session.exists(env.path):
+                # The location and version of virtualenv are recorded at the
+                # time of tracing, but should we use these values?  For now,
+                # use a plain "virtualenv" below on the basis that we just use
+                # "apt-get" and "git" elsewhere.
+                session.execute_command(["virtualenv",
+                                         "--python=python{}".format(pyver),
+                                         env.path])
+            list(execute_command_batch(session,
+                                       [env.path + "/bin/pip", "install"],
+                                       to_install))
 
 
 class VenvTracer(DistributionTracer):

--- a/niceman/distributions/venv.py
+++ b/niceman/distributions/venv.py
@@ -162,7 +162,7 @@ class VenvTracer(DistributionTracer):
             out, err = self._session.execute_command(
                 [venv_path + "/bin/python", "--version"])
             # Python 2 sends its version to stderr, while Python 3
-            # sends it to stdout.  Version has format "Python
+            # sends it to stdout.
             pyver = out if "Python" in out else err
             return pyver.strip().split()[1]
         except Exception as exc:

--- a/niceman/tests/test_utils.py
+++ b/niceman/tests/test_utils.py
@@ -42,6 +42,7 @@ from ..utils import _path_
 from ..utils import to_unicode
 from ..utils import generate_unique_name
 from ..utils import PathRoot, is_subpath
+from ..utils import parse_semantic_version
 
 from .utils import ok_, eq_, assert_false, assert_equal, assert_true
 
@@ -480,6 +481,19 @@ def test_is_subpath(tmpdir):
     assert is_subpath("/tmp", "/tmp")
     # Trailing slashes don't matter.
     assert is_subpath("/tmp/", "/tmp")
+
+
+def test_parse_semantic_version():
+    for version, expected in [("1.2.3", ("1", "2", "3", "")),
+                              ("12.2.33", ("12", "2", "33", "")),
+                              ("1.2.3.rc1", ("1", "2", "3", ".rc1")),
+                              ("1.2.3-blah", ("1", "2", "3", "-blah"))]:
+        assert parse_semantic_version(version) == expected
+
+    with pytest.raises(ValueError):
+        parse_semantic_version("X.Y.Z")
+    with pytest.raises(ValueError):
+        parse_semantic_version("1.2")
 
 
 def test_line_profile():

--- a/niceman/utils.py
+++ b/niceman/utils.py
@@ -1226,4 +1226,31 @@ def is_subpath(path, directory):
     return not os.path.relpath(path, directory).startswith(os.path.pardir)
 
 
+SemanticVersion = collections.namedtuple("SemanticVersion",
+                                         ["major", "minor", "patch", "tag"])
+
+
+def parse_semantic_version(version):
+    """Split version into major, minor, patch, and tag components.
+
+    Parameters
+    ----------
+    version : str
+        A version string X.Y.Z.  X, Y, and Z must be digits.  Any remaining
+        text is treated as a tag (e.g., "-rc1").
+
+    Returns
+    -------
+    A namedtuple with the form (major, minor, patch, tag).
+    """
+    m = re.match(r"(?P<major>[0-9]+)\.(?P<minor>[0-9]+)\.(?P<patch>[0-9]+)"
+                 r"(?P<tag>.*)",
+                 version)
+    if m:
+        return SemanticVersion(*m.groups())
+    else:
+        raise ValueError(
+            "{} does not appear to follow semantic versioning".format(version))
+
+
 lgr.log(5, "Done importing niceman.utils")


### PR DESCRIPTION
Add support for installing non-editable, local packages.

Some current limitations:

  * If a virtualenv directory already exists at a path, running "install" can upgrade/downgrade the packages in the spec to the recorded version, but that's all.  There is no check of the python version or whether the environment has additional packages.

  * We don't handle system or editable packages.

Both of these issues involve components outside of the virtualenv distribution, so to address them we'd need to define a way for the installation procedures of different distributions to interact.
