### PR TITLE
 BF: piputils: Rework approach for pip 18.0 compatibility

### DIFF
--- a/niceman/distributions/piputils.py
+++ b/niceman/distributions/piputils.py
@@ -9,6 +9,7 @@
 """Utilities for working with pip.
 """
 import itertools
+import json
 import os
 import re
 
@@ -87,19 +88,8 @@ def pip_show(session, which_pip, pkgs):
     return packages, file_to_pkg
 
 
-def parse_pip_list(out):
-    """Parse the output of `pip list --format=legacy`.
-    """
-    pkg_re = re.compile(r"^(?P<package>[^(]+) "
-                        r"\((?P<version>.*?)"
-                        r"(?:, (?P<location>.*))?\)$",
-                        re.MULTILINE)
-    for pkg, version, location in pkg_re.findall(out):
-        yield pkg.lower(), version, location or None
-
-
 def pip_list(session, which_pip, args=None):
-    """Return output of `pip list --format=legacy`.
+    """Return output of `pip list`.
 
     Parameters
     ----------
@@ -112,25 +102,18 @@ def pip_list(session, which_pip, args=None):
 
     Returns
     -------
-    A generator that yields (name, version, location) for each
-    package.  Location will be None unless the package is editable.
+    A generator that yields (name, version) for each package.
     """
     # We could use either 'pip list' or 'pip freeze' to get a list
     # of packages.  The choice to use 'list' rather than 'freeze'
     # is based on how they show editable packages.  'list' outputs
     # a source directory of the package, whereas 'freeze' outputs
     # a URL like "-e git+https://github.com/[...]".
-    #
-    # It would be nice to use 'pip list --format=json' rather than
-    # the legacy format.  However, currently (pip 9.0.1, 2018/01),
-    # the json format does not include location information for
-    # editable packages (though it is supported in a developmental
-    # version).
-    cmd = [which_pip, "list", "--format=legacy"]
+    cmd = [which_pip, "list", "--format=json"]
     if args:
         cmd.extend(args)
     out, _ = session.execute_command(cmd)
-    return parse_pip_list(out)
+    return ((p["name"], p["version"]) for p in json.loads(out))
 
 
 def get_pip_packages(session, which_pip, restriction=None):
@@ -155,7 +138,7 @@ def get_pip_packages(session, which_pip, restriction=None):
         args = ["--{}".format(restriction)]
     else:
         args = None
-    return (pkg for pkg, _, _ in pip_list(session, which_pip, args))
+    return (pkg for pkg, _ in pip_list(session, which_pip, args))
 
 
 def get_package_details(session, which_pip, packages=None):
@@ -179,13 +162,12 @@ def get_package_details(session, which_pip, packages=None):
     A tuple of two dicts, where the first maps a package name to its
     details and the second maps package files to the package name.
     """
-    pkgs, _, editlocs = zip(*pip_list(session, which_pip))
-
     if packages is None:
-        packages = pkgs
-
-    pkg_to_editloc = dict(zip(pkgs, editlocs))
+        packages = list(get_pip_packages(session, which_pip))
+    editable_packages = set(
+        get_pip_packages(session, which_pip, restriction="editable"))
     details, file_to_pkg = pip_show(session, which_pip, packages)
+
     for pkg in details:
-        details[pkg]["editable"] = pkg_to_editloc[pkg] is not None
+        details[pkg]["editable"] = pkg in editable_packages
     return details, file_to_pkg

--- a/niceman/distributions/piputils.py
+++ b/niceman/distributions/piputils.py
@@ -98,7 +98,7 @@ def parse_pip_list(out):
         yield pkg.lower(), version, location or None
 
 
-def pip_list(session, which_pip, local_only=False):
+def pip_list(session, which_pip, args=None):
     """Return output of `pip list --format=legacy`.
 
     Parameters
@@ -107,11 +107,8 @@ def pip_list(session, which_pip, local_only=False):
         Session in which to execute the command.
     which_pip : str
         Name of the pip executable.
-    local_only : boolean, optional
-        Do not include globally installed packages.  Otherwise, global
-        packages will be included if pip has global access (e.g.,
-        "--system-site-packages" was used when creating the virtualenv
-        directory).
+    args : list, optional
+        Other arguments passed to `pip list`.
 
     Returns
     -------
@@ -130,13 +127,13 @@ def pip_list(session, which_pip, local_only=False):
     # editable packages (though it is supported in a developmental
     # version).
     cmd = [which_pip, "list", "--format=legacy"]
-    if local_only:
-        cmd.append("--local")
+    if args:
+        cmd.extend(args)
     out, _ = session.execute_command(cmd)
     return parse_pip_list(out)
 
 
-def get_pip_packages(session, which_pip, local_only=False):
+def get_pip_packages(session, which_pip, restriction=None):
     """Return a list of pip packages.
 
     Parameters
@@ -145,17 +142,17 @@ def get_pip_packages(session, which_pip, local_only=False):
         Session in which to execute the command.
     which_pip : str
         Name of the pip executable.
-    local_only : boolean, optional
-        Do not include globally installed packages.  Otherwise, global
-        packages will be included if pip has global access (e.g.,
-        "--system-site-packages" was used when creating the virtualenv
+    restriction : {None, 'local'}, optional
+        If 'local', excluded globally installed packages (which pip has access
+        to if "--system-site-packages" was used when creating the virtualenv
         directory).
 
     Returns
     -------
     A generator that yields package names.
     """
-    return (pkg for pkg, _, _ in pip_list(session, which_pip, local_only))
+    args = ["--local"] if restriction == "local" else []
+    return (pkg for pkg, _, _ in pip_list(session, which_pip, args))
 
 
 def get_package_details(session, which_pip, packages=None):

--- a/niceman/distributions/piputils.py
+++ b/niceman/distributions/piputils.py
@@ -142,16 +142,19 @@ def get_pip_packages(session, which_pip, restriction=None):
         Session in which to execute the command.
     which_pip : str
         Name of the pip executable.
-    restriction : {None, 'local'}, optional
+    restriction : {None, 'local', 'editable'}, optional
         If 'local', excluded globally installed packages (which pip has access
         to if "--system-site-packages" was used when creating the virtualenv
-        directory).
+        directory). If 'editable', only include editable packages.
 
     Returns
     -------
     A generator that yields package names.
     """
-    args = ["--local"] if restriction == "local" else []
+    if restriction in ["local", "editable"]:
+        args = ["--{}".format(restriction)]
+    else:
+        args = None
     return (pkg for pkg, _, _ in pip_list(session, which_pip, args))
 
 

--- a/niceman/distributions/tests/test_piputils.py
+++ b/niceman/distributions/tests/test_piputils.py
@@ -84,17 +84,3 @@ Cannot locate installed-files.txt"""
     info_nofiles = piputils.parse_pip_show(out_no_files)
     assert set(info_nofiles.keys()) == fields
     assert info_nofiles["Files"] == []
-
-
-def test_parse_pip_list():
-    out= """\
-pythis (1.4.3)
-pythat (0.1.0, /local/path)
-pypypypy (2.2.0)
-comma_in_vers (2.2,0)"""
-    expect = [("pythis", "1.4.3", None),
-              ("pythat", "0.1.0", "/local/path"),
-              ("pypypypy", "2.2.0", None),
-              ("comma_in_vers", "2.2,0", None)]
-    result = list(piputils.parse_pip_list(out))
-    assert expect == result

--- a/niceman/distributions/tests/test_venv.py
+++ b/niceman/distributions/tests/test_venv.py
@@ -48,6 +48,8 @@ def venv_test_dir():
         runner.run(["./venv0/bin/pip", "install", "pyyaml"])
         runner.run(["./venv0/bin/pip", "install", "-e", pymod_dir])
         runner.run(["./venv1/bin/pip", "install", "attrs"])
+        # Make sure we're compatible with older pips.
+        runner.run(["./venv1/bin/pip", "install", "pip==9.0.3"])
     return test_dir
 
 

--- a/niceman/distributions/venv.py
+++ b/niceman/distributions/venv.py
@@ -142,7 +142,7 @@ class VenvTracer(DistributionTracer):
             package_details, file_to_pkg = self._get_package_details(venv_path)
             local_pkgs = set(piputils.get_pip_packages(self._session,
                                                        venv_path + "/bin/pip",
-                                                       local_only=True))
+                                                       restriction="local"))
             pkg_to_found_files = defaultdict(list)
             for path in set(unknown_files):  # Clone the set
                 # The supplied path may be relative or absolute, but


### PR DESCRIPTION
```
We use the legacy format of 'pip list' because the legacy format
contains an extra location field for editable packages.  Using
'--format=json --verbose' doesn't provide the same information: pip
<10.0 doesn't include locations at all, and pip >=10.0 does include
locations, but unlike in the legacy output, every package has a
location, so the json output can't be used to identify editable
packages.

However, as of pip 18.0 (2018-07-22), 'pip list' no longer supports
'--format=legacy'.  Instead, make another call to pip to retrieve a
list of editable packages to use to set the 'editable' attribute.
```

Fixes #271.
