### PR TITLE
 BF: DebTracer.get_package_details: Handle empty package list

### DIFF
--- a/niceman/distributions/debian.py
+++ b/niceman/distributions/debian.py
@@ -399,6 +399,9 @@ class DebTracer(DistributionTracer):
         return name
 
     def get_details_for_packages(self, packages):
+        if not packages:
+            return []
+
         # Find apt sources if not defined
         if not self._all_apt_sources:
             self._find_all_sources()

--- a/niceman/distributions/tests/test_debian.py
+++ b/niceman/distributions/tests/test_debian.py
@@ -112,6 +112,16 @@ def list_all_files(dir):
 #             fp('oths_d_d_data_non-free_binary-i386_Packages')) is None
 
 
+def test_trace_nonexisting_file():
+    files = ["/is/not/there/"]
+    manager = DebTracer()
+    packages, unknown_files = manager.identify_packages_from_files(files)
+    # get_details_for_packages doesn't fail on an empty package list.
+    assert not packages
+    packages = manager.get_details_for_packages(packages)
+    assert not packages
+
+
 def test_utf8_file():
     files = [u"/usr/share/ca-certificates/mozilla/"
              u"TÜBİTAK_UEKAE_Kök_Sertifika_Hizmet_Sağlayıcısı_-_Sürüm_3.crt"]

--- a/niceman/tests/test_utils.py
+++ b/niceman/tests/test_utils.py
@@ -23,7 +23,8 @@ from os.path import dirname, normpath, pardir, basename
 from os.path import isabs, expandvars, expanduser
 from collections import OrderedDict
 
-from ..utils import updated, HashableDict, execute_command_batch, \
+from ..utils import updated, HashableDict, \
+    get_cmd_batch_len, execute_command_batch, \
     cmd_err_filter, join_sequence_of_dicts
 from os.path import join as opj, abspath, exists
 from ..utils import rotree, swallow_outputs, swallow_logs, setup_exceptionhook, md5sum
@@ -428,6 +429,13 @@ def test_join_sequence_of_dicts():
            {"a": 1, "b": 2, "c": 3, "d": 4}
     with pytest.raises(RuntimeError):
         join_sequence_of_dicts(({"a": 1, "b": 2}, {"b": 3}, {"d": 4}))
+
+
+def test_get_cmd_batch_len_empty():
+    with pytest.raises(ValueError) as cm:
+        get_cmd_batch_len([], 10)
+    cm.match("Cannot batch")
+
 
 def test_execute_command_batch():
     # Create a dummy session that can possibly raise a ValueError

--- a/niceman/utils.py
+++ b/niceman/utils.py
@@ -979,6 +979,8 @@ def get_cmd_batch_len(arg_list, cmd_len):
     number
       The maximum number in a single batch
     """
+    if not arg_list:
+        raise ValueError("Cannot batch an empty argument list")
     # Pick a conservative max command-line length
     try:
         _MAX_LEN_CMDLINE = os.sysconf(str("SC_ARG_MAX")) // 2


### PR DESCRIPTION
After a recent system update, `test_debian.py:test_utf8_file` is failing locally for me.  That test is designed to not assume that the "*.crt" file exists, but it still fails because of `get_details_for_packages` can't handle an empty list.


- [X] make `get_package_details handle` an empty list
- [X] give `get_cmd_batch_len` a more information exception message in the case of an empty list
