### PR TITLE
Restrict reprozip dependency to Linux

### DIFF
--- a/niceman/interface/exec.py
+++ b/niceman/interface/exec.py
@@ -211,8 +211,13 @@ class Exec(Interface):
                     "Not copying %s from remote session since already exists locally",
                     local_trace_dir)
 
-            from reprozip.tracer.trace import write_configuration
+            try:
+                from reprozip.tracer.trace import write_configuration
+            except ImportError:
+                raise RuntimeError("Using --trace requires ReproZip, "
+                                   "a Linux-specific dependency")
             from rpaths import Path
+
             # we rely on hardcoded paths in reprozip
             write_configuration(
                 directory=Path(local_trace_dir),

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ requires = {
         'pycrypto',
         'pyOpenSSL==16.2.0',
         'requests',
-        'reprozip',
+        'reprozip; sys_platform=="linux" or sys_platform=="linux2"',
         'rpaths',
     ],
     'debian': [


### PR DESCRIPTION
At the moment NICEMAN functionality on systems other than GNU/Linux
ones is fairly limited and untested, but we intend to support other
systems, so we can't list ReproZip as an unconditionally requirement.

Fixes #276.

---

This hits a branch of code that needs test coverage, but I don't see a reason to hold this up for it.