### PR TITLE
ENH: Suggest backend parameters when an unknown value is given

### DIFF
--- a/niceman/interface/base.py
+++ b/niceman/interface/base.py
@@ -22,6 +22,7 @@ from ..ui import ui
 from ..dochelpers import exc_str
 from ..resource import ResourceManager
 from ..resource import Resource
+from ..resource.base import get_resource_backends
 from ..support.exceptions import ResourceError
 from logging import getLogger
 lgr = getLogger('niceman.interface')
@@ -266,11 +267,9 @@ def backend_help(resource_type=None):
                 module, class_name
             )
             continue
-        args = attr.fields(cls)
-        for arg in args:
-            if 'doc' in arg.metadata:
-                help_args.append('"{}" ({})'.format(arg.name, arg.metadata['doc']))
-
+        help_args.extend(
+            ['"{}" ({})'.format(bname, bdoc)
+             for bname, bdoc in sorted(get_resource_backends(cls).items())])
     return help_message + ", ".join(help_args)
 
 

--- a/niceman/interface/login.py
+++ b/niceman/interface/login.py
@@ -11,15 +11,12 @@
 
 __docformat__ = 'restructuredtext'
 
-import re
-
 from .base import Interface, backend_help
 import niceman.interface.base # Needed for test patching
 from niceman.resource import get_manager
 from .common_opts import resref_arg
 from .common_opts import resref_type_opt
 from ..support.param import Parameter
-from ..support.constraints import EnsureStr
 
 from logging import getLogger
 lgr = getLogger('niceman.api.login')

--- a/niceman/interface/login.py
+++ b/niceman/interface/login.py
@@ -11,12 +11,11 @@
 
 __docformat__ = 'restructuredtext'
 
-from .base import Interface, backend_help
+from .base import Interface
 import niceman.interface.base # Needed for test patching
 from niceman.resource import get_manager
 from .common_opts import resref_arg
 from .common_opts import resref_type_opt
-from ..support.param import Parameter
 
 from logging import getLogger
 lgr = getLogger('niceman.api.login')
@@ -33,17 +32,12 @@ class Login(Interface):
     """
 
     _params_ = dict(
-        backend=Parameter(
-            args=("-b", "--backend"),
-            nargs="+",
-            doc=backend_help()
-        ),
         resref=resref_arg,
         resref_type=resref_type_opt,
     )
 
     @staticmethod
-    def __call__(resref, resref_type="auto", backend=None):
+    def __call__(resref, resref_type="auto"):
         env_resource = get_manager().get_resource(resref, resref_type)
 
         # Connect to resource environment

--- a/niceman/resource/base.py
+++ b/niceman/resource/base.py
@@ -59,9 +59,20 @@ def backend_set_config(params, env_resource, config):
         else:
             known = get_resource_backends(env_resource.__class__)
             if known:
-                help_msg = "\n  Known backend parameters:\n{}\n".format(
+                import difflib
+
+                suggestions = {s: known[s]
+                               for s in difflib.get_close_matches(key, known)}
+                if suggestions:
+                    title = "Did you mean?"
+                    params = suggestions
+                else:
+                    title = "Known backend parameters:"
+                    params = known
+                help_msg = "\n  {}\n{}\n".format(
+                    title,
                     "\n".join(["    {} ({})".format(bname, bdoc)
-                               for bname, bdoc in sorted(known.items())]))
+                               for bname, bdoc in sorted(params.items())]))
                 msg = "Bad --backend parameter '{}'{}".format(key, help_msg)
             else:
                 msg = "Resource type {!r} has no known parameters".format(

--- a/niceman/resource/base.py
+++ b/niceman/resource/base.py
@@ -57,7 +57,16 @@ def backend_set_config(params, env_resource, config):
             config[key] = value
             setattr(env_resource, key, value)
         else:
-            raise ResourceError("Bad --backend parameter '{}'".format(key))
+            known = get_resource_backends(env_resource.__class__)
+            if known:
+                help_msg = "\n  Known backend parameters:\n{}\n".format(
+                    "\n".join(["    {} ({})".format(bname, bdoc)
+                               for bname, bdoc in sorted(known.items())]))
+                msg = "Bad --backend parameter '{}'{}".format(key, help_msg)
+            else:
+                msg = "Resource type {!r} has no known parameters".format(
+                    env_resource.type)
+            raise ResourceError(msg)
 
 
 class ResourceManager(object):

--- a/niceman/resource/base.py
+++ b/niceman/resource/base.py
@@ -32,6 +32,13 @@ import logging
 lgr = logging.getLogger('niceman.resource.base')
 
 
+def get_resource_backends(cls):
+    """Return name to documentation mapping of `cls`s backends.
+    """
+    return {b.name: b.metadata["doc"] for b in attr.fields(cls)
+            if "doc" in b.metadata}
+
+
 def backend_set_config(params, env_resource, config):
     """Set backend parameters in resource instance and config.
 

--- a/niceman/resource/base.py
+++ b/niceman/resource/base.py
@@ -50,7 +50,7 @@ def backend_set_config(params, env_resource, config):
             config[key] = value
             setattr(env_resource, key, value)
         else:
-            raise NotImplementedError("Bad --backend parameter '{}'".format(key))
+            raise ResourceError("Bad --backend parameter '{}'".format(key))
 
 
 class ResourceManager(object):

--- a/niceman/resource/tests/test_base.py
+++ b/niceman/resource/tests/test_base.py
@@ -5,11 +5,9 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-import mock
 import os.path as op
 import pytest
 
-from niceman.resource.base import Resource
 from niceman.resource.base import ResourceManager
 from niceman.resource.base import backend_set_config
 from niceman.resource.shell import Shell

--- a/niceman/resource/tests/test_base.py
+++ b/niceman/resource/tests/test_base.py
@@ -11,6 +11,7 @@ import pytest
 from niceman.resource.base import ResourceManager
 from niceman.resource.base import backend_set_config
 from niceman.resource.shell import Shell
+from niceman.resource.docker_container import DockerContainer
 from niceman.support.exceptions import MissingConfigError
 from niceman.support.exceptions import MultipleResourceMatches
 from niceman.support.exceptions import ResourceAlreadyExistsError
@@ -27,11 +28,20 @@ def test_resource_manager_factory_unkown():
         ResourceManager.factory({"type": "not really a type"})
 
 
-def test_backend_set_config():
-    with pytest.raises(ResourceError):
+def test_backend_set_config_no_known():
+    with pytest.raises(ResourceError) as exc:
         backend_set_config(["unknown_key=value"],
                            Shell(name="test-shell"),
                            {})
+    assert "no known parameters" in str(exc.value)
+
+
+def test_backend_set_config_nowhere_close():
+    with pytest.raises(ResourceError) as exc:
+        backend_set_config(["unknown_key=value"],
+                           DockerContainer(name="foo"),
+                           {})
+    assert "Known backend parameters" in str(exc.value)
 
 
 def test_resource_manager_empty_init(tmpdir):

--- a/niceman/resource/tests/test_base.py
+++ b/niceman/resource/tests/test_base.py
@@ -28,7 +28,7 @@ def test_resource_manager_factory_unkown():
 
 
 def test_backend_set_config():
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(ResourceError):
         backend_set_config(["unknown_key=value"],
                            Shell(name="test-shell"),
                            {"type": "shell", "name": "test-shell"})

--- a/niceman/resource/tests/test_base.py
+++ b/niceman/resource/tests/test_base.py
@@ -31,7 +31,7 @@ def test_backend_set_config():
     with pytest.raises(ResourceError):
         backend_set_config(["unknown_key=value"],
                            Shell(name="test-shell"),
-                           {"type": "shell", "name": "test-shell"})
+                           {})
 
 
 def test_resource_manager_empty_init(tmpdir):

--- a/niceman/resource/tests/test_base.py
+++ b/niceman/resource/tests/test_base.py
@@ -44,6 +44,14 @@ def test_backend_set_config_nowhere_close():
     assert "Known backend parameters" in str(exc.value)
 
 
+def test_backend_set_config_close_match():
+    with pytest.raises(ResourceError) as exc:
+        backend_set_config(["imagee=value"],
+                           DockerContainer(name="foo"),
+                           {})
+    assert "Did you mean?" in str(exc.value)
+
+
 def test_resource_manager_empty_init(tmpdir):
     inventory = op.join(str(tmpdir), "inventory.yml")
     manager = ResourceManager(inventory)


### PR DESCRIPTION
### Before

When `create` is given a backend parameters, but the resource doesn't have parameters or the given parameter doesn't match, we showed

```
2018-09-11 13:33:43,032 [ERROR  ] Bad --backend parameter 'imagee' [base.py:backend_set_config:53] (NotImplementedError) 
```

### After 

Resource without parameters:

```
$ niceman create -t shell shellbert -b imagee=foo 
2018-09-11 13:29:49,342 [ERROR  ] Resource type 'shell' has no known parameters [base.py:backend_set_config:80] (ResourceError) 
```

Resource has parameters, but nothing close to what was given:

```
$ niceman create -t docker-container dockerbert -b not-even-close=foo
2018-09-11 13:31:04,455 [ERROR  ] Bad --backend parameter 'not-even-close'
|   Known backend parameters:
|     engine_url (Docker server URL where engine is listening for connections)
|     image (Docker base image ID from which to create the running instance)
|     seccomp_unconfined (Disable kernel secure computing mode when creating the container)
|  [base.py:backend_set_config:80] (ResourceError) 
```

Supplied value was cloase: 

```
$ niceman create -t docker-container dockerbert -b imagee=foo     
2018-09-11 13:30:30,584 [ERROR  ] Bad --backend parameter 'imagee'
|   Did you mean?
|     image (Docker base image ID from which to create the running instance)
|  [base.py:backend_set_config:80] (ResourceError) 
```

---

Closes #283. 