### PR TITLE
List backend parameters with command rather than as unformatted block

### DIFF
--- a/niceman/interface/__init__.py
+++ b/niceman/interface/__init__.py
@@ -35,6 +35,7 @@ _group_misc = (
     'Miscellaneous commands',
     [
         ('niceman.interface.ls', 'Ls'),
+        ('niceman.interface.backend_parameters', 'BackendParameters'),
         # ('niceman.interface.trace', 'Trace'),
         # ('niceman.interface.shell', 'Shell'),
         ('niceman.interface.retrace', 'Retrace'),

--- a/niceman/interface/backend_parameters.py
+++ b/niceman/interface/backend_parameters.py
@@ -1,0 +1,80 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil; coding: utf-8 -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the niceman package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Provide information about available backend parameters.
+"""
+
+__docformat__ = 'restructuredtext'
+
+from importlib import import_module
+from logging import getLogger
+
+from niceman.dochelpers import exc_str
+from niceman.interface.base import Interface
+from niceman.resource import Resource
+from niceman.resource.base import ResourceManager
+from niceman.resource.base import get_resource_backends
+from niceman.support.constraints import EnsureStr
+from niceman.support.param import Parameter
+
+
+lgr = getLogger('niceman.api.backend_parameters')
+
+
+def get_resource_classes(names=None):
+    for name in names or ResourceManager._discover_types():
+        try:
+            module = import_module('niceman.resource.{}'.format(name))
+        except ImportError as exc:
+            import difflib
+            known = ResourceManager._discover_types()
+            suggestions = difflib.get_close_matches(name, known)
+            lgr.warning(
+                "Failed to import resource %s: %s. %s: %s",
+                name,
+                exc_str(exc),
+                "Similar backends" if suggestions else "Known backends",
+                ', '.join(suggestions or known))
+            continue
+
+        class_name = ''.join([token.capitalize() for token in name.split('_')])
+        cls = getattr(module, class_name)
+        if issubclass(cls, Resource):
+            yield name, cls
+        else:
+            lgr.debug("Skipping %s.%s because it is not a Resource. "
+                      "Consider moving away",
+                      module, class_name)
+
+
+class BackendParameters(Interface):
+    """Display available backend parameters.
+    """
+
+    _params_ = dict(
+        backends=Parameter(
+            args=("backends",),
+            metavar="BACKEND",
+            doc="""Restrict output to this backend.""",
+            constraints=EnsureStr(),
+            nargs="*")
+    )
+
+    @staticmethod
+    def __call__(backends=None):
+        backends = backends or ResourceManager._discover_types()
+        for backend, cls in get_resource_classes(backends):
+            param_doc = "\n".join(
+                ["  {}: {}".format(p, pdoc)
+                 for p, pdoc in sorted(get_resource_backends(cls).items())])
+            if param_doc:
+                out = "Backend parameters for '{}'\n{}".format(
+                    backend, param_doc)
+            else:
+                out = "No backend parameters for '{}'".format(backend)
+            print(out)

--- a/niceman/interface/create.py
+++ b/niceman/interface/create.py
@@ -67,15 +67,16 @@ class Create(Interface):
         #     choices=("fail", "redefine"),
         #     doc="Action to take if name is already known"
         # ),
-        backend=Parameter(
-            args=("-b", "--backend"),
+        backend_parameters=Parameter(
+            metavar="PARAM",
+            args=("-b", "--backend-parameters"),
             nargs="+",
             doc=backend_help()
         ),
     )
 
     @staticmethod
-    def __call__(name, resource_type, backend):
+    def __call__(name, resource_type, backend_parameters):
         # Load, while possible merging/augmenting sequentially
         # provenance = Provenance.factory(specs)
         #
@@ -111,7 +112,7 @@ class Create(Interface):
         # TODO: Add ability to clone a resource.
 
         get_manager().create(name, resource_type,
-                             parse_backend_parameters(backend or []))
+                             parse_backend_parameters(backend_parameters or []))
         lgr.info("Created the environment %s", name)
 
         # TODO: at the end install packages using install and created env

--- a/niceman/interface/create.py
+++ b/niceman/interface/create.py
@@ -11,7 +11,7 @@
 
 __docformat__ = 'restructuredtext'
 
-from .base import Interface, backend_help
+from .base import Interface
 import niceman.interface.base # Needed for test patching
 from ..support.param import Parameter
 from ..support.constraints import EnsureStr
@@ -71,7 +71,9 @@ class Create(Interface):
             metavar="PARAM",
             args=("-b", "--backend-parameters"),
             nargs="+",
-            doc=backend_help()
+            doc="""One or more backend parameters in the form KEY=VALUE. Use
+            the command `niceman backend-parameters` to see the list of
+            available backend parameters."""
         ),
     )
 

--- a/niceman/interface/tests/test_backend_parameters.py
+++ b/niceman/interface/tests/test_backend_parameters.py
@@ -1,0 +1,35 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the niceman package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+
+import logging
+import mock
+from six.moves import StringIO
+
+from niceman.api import backend_parameters
+from niceman.utils import swallow_logs
+
+
+def test_backend_parameters_unknown_resource():
+    with swallow_logs(new_level=logging.WARNING) as log:
+        backend_parameters(["i'm-unknown"])
+        assert "Failed to import" in log.out
+
+
+def test_backend_parameters_with_arg():
+    with mock.patch('sys.stdout', new_callable=StringIO) as out:
+        backend_parameters(["ssh"])
+    assert "host:" in out.getvalue()
+    assert "aws_ec2" not in out.getvalue()
+
+
+def test_backend_parameters_all():
+    with mock.patch('sys.stdout', new_callable=StringIO) as out:
+        backend_parameters()
+    assert "host:" in out.getvalue()
+    assert "aws_ec2" in out.getvalue()

--- a/niceman/interface/tests/test_create.py
+++ b/niceman/interface/tests/test_create.py
@@ -19,7 +19,6 @@ from niceman.resource.base import ResourceManager
 from niceman.tests.utils import assert_in
 from niceman.support.exceptions import ResourceError
 
-from ..create import backend_help
 from ..create import parse_backend_parameters
 
 
@@ -72,12 +71,6 @@ def test_create_missing_required():
                    return_value=ResourceManager()):
             create("somessh", "ssh", [])
     assert "host" in str(exc.value)
-
-
-def test_backend_help_wrong_backend():
-    with pytest.raises(ResourceError) as exc:
-        backend_help("unknown_backend")
-    assert 'Known ones are: aws' in str(exc)
 
 
 def test_parse_backend_parameters():


### PR DESCRIPTION
Rather than 

```
Usage: niceman create [--version] [-h]
[...]
  -b BACKEND [BACKEND ...], --backend BACKEND [BACKEND ...]
                        One or more backend parameters in the form KEY=VALUE.
                        Options are: "access_key_id" (AWS access key for
                        remote access to your Amazon subscription.), "image"
                        (AWS image ID from which to create the running
                        instance), "instance_type" (The type of Amazon EC2
                        instance to run. (e.g. t2.medium)), "key_filename"
                        (Path to SSH private key file matched with AWS key
                        name parameter.), "key_name" (AWS subscription name of
                        SSH key-pair registered.), "region_name" (AWS
                        availability zone to run the EC2 instance in. (e.g.
                        us-east-1)), "secret_access_key" (AWS secret access
                        key for remote access to your Amazon subscription),
                        "security_group" (AWS security group to assign to the
                        EC2 instance.), "user" (Login account to EC2
                        instance.), "engine_url" (Docker server URL where
                        engine is listening for connections), "image" (Docker
                        base image ID from which to create the running
                        instance), "seccomp_unconfined" (Disable kernel secure
                        computing mode when creating the container), "image"
                        (Base image filename or url), "host" (DNS or IP
                        address of server), "key_filename" (Path to SSH
                        private key file matched with AWS key name parameter),
                        "port" (Port to connect to on remote host), "user"
                        (Username to use to log into remote environment).

```

... show this

```
$ niceman create --help
[...]
  -b PARAM [PARAM ...], --backend-parameters PARAM [PARAM ...]
                        One or more backend parameters in the form KEY=VALUE.
                        Use the command `niceman backend-parameters` to see
                        the list of available backend parameters.


$ niceman backend-parameters
Backend parameters for 'aws_ec2' 
  access_key_id: AWS access key for remote access to your Amazon subscription.
  image: AWS image ID from which to create the running instance
  instance_type: The type of Amazon EC2 instance to run. (e.g. t2.medium)
  key_filename: Path to SSH private key file matched with AWS key name parameter.
  key_name: AWS subscription name of SSH key-pair registered.
  region_name: AWS availability zone to run the EC2 instance in. (e.g. us-east-1)
  secret_access_key: AWS secret access key for remote access to your Amazon subscription
  security_group: AWS security group to assign to the EC2 instance.
  user: Login account to EC2 instance.
Backend parameters for 'docker_container'
  engine_url: Docker server URL where engine is listening for connections
  image: Docker base image ID from which to create the running instance
  seccomp_unconfined: Disable kernel secure computing mode when creating the container
No backend parameters for 'shell'
Backend parameters for 'singularity'
  image: Base image filename or url
Backend parameters for 'ssh'
  host: DNS or IP address of server
  key_filename: Path to SSH private key file matched with AWS key name parameter
  port: Port to connect to on remote host
  user: Username to use to log into remote environment

$ niceman backend-parameters ssh
Backend parameters for 'ssh'
  host: DNS or IP address of server
  key_filename: Path to SSH private key file matched with AWS key name parameter
  port: Port to connect to on remote host
  user: Username to use to log into remote environment


```
---

Fixes #284.