### PR TITLE
 ENH: Support required backend parameters

### DIFF
--- a/niceman/interface/create.py
+++ b/niceman/interface/create.py
@@ -23,6 +23,10 @@ from logging import getLogger
 lgr = getLogger('niceman.api.create')
 
 
+def parse_backend_parameters(params):
+    return dict(p.split("=") for p in params)
+
+
 class Create(Interface):
     """Create a computation environment
     """
@@ -106,7 +110,8 @@ class Create(Interface):
 
         # TODO: Add ability to clone a resource.
 
-        get_manager().create(name, resource_type, backend)
+        get_manager().create(name, resource_type,
+                             parse_backend_parameters(backend or []))
         lgr.info("Created the environment %s", name)
 
         # TODO: at the end install packages using install and created env

--- a/niceman/interface/create.py
+++ b/niceman/interface/create.py
@@ -24,7 +24,7 @@ lgr = getLogger('niceman.api.create')
 
 
 def parse_backend_parameters(params):
-    return dict(p.split("=") for p in params)
+    return dict(p.split("=", 1) for p in params)
 
 
 class Create(Interface):

--- a/niceman/interface/tests/test_create.py
+++ b/niceman/interface/tests/test_create.py
@@ -19,6 +19,7 @@ from niceman.tests.utils import assert_in
 from niceman.support.exceptions import ResourceError
 
 from ..create import backend_help
+from ..create import parse_backend_parameters
 
 
 def test_create_interface():
@@ -67,3 +68,10 @@ def test_backend_help_wrong_backend():
     with pytest.raises(ResourceError) as exc:
         backend_help("unknown_backend")
     assert 'Known ones are: aws' in str(exc)
+
+
+def test_parse_backend_parameters():
+    for value, expected in [(["a=b"], {"a": "b"}),
+                            (["a="], {"a": ""}),
+                            (["a-b=c d"], {"a-b": "c d"})]:
+        assert parse_backend_parameters(value) == expected

--- a/niceman/interface/tests/test_create.py
+++ b/niceman/interface/tests/test_create.py
@@ -73,5 +73,6 @@ def test_backend_help_wrong_backend():
 def test_parse_backend_parameters():
     for value, expected in [(["a=b"], {"a": "b"}),
                             (["a="], {"a": ""}),
+                            (["a=c=d"], {"a": "c=d"}),
                             (["a-b=c d"], {"a-b": "c d"})]:
         assert parse_backend_parameters(value) == expected

--- a/niceman/interface/tests/test_create.py
+++ b/niceman/interface/tests/test_create.py
@@ -12,6 +12,7 @@ import logging
 import pytest
 from mock import patch, call, MagicMock
 
+from niceman.api import create
 from niceman.cmdline.main import main
 from niceman.utils import swallow_logs
 from niceman.resource.base import ResourceManager
@@ -62,6 +63,15 @@ def test_create_interface():
         assert_in("status 1 progress 1", log.lines)
         assert_in("status 2 progress 2", log.lines)
         assert_in("Created the environment my-test-resource", log.lines)
+
+
+def test_create_missing_required():
+    with pytest.raises(ResourceError) as exc:
+        # SSH requires host.
+        with patch("niceman.interface.create.get_manager",
+                   return_value=ResourceManager()):
+            create("somessh", "ssh", [])
+    assert "host" in str(exc.value)
 
 
 def test_backend_help_wrong_backend():

--- a/niceman/resource/base.py
+++ b/niceman/resource/base.py
@@ -116,7 +116,7 @@ class ResourceManager(object):
 
         Parameters
         ----------
-        resource_config : dict
+        config : dict
             Configuration parameters for the resource.
 
         Returns

--- a/niceman/resource/base.py
+++ b/niceman/resource/base.py
@@ -32,6 +32,12 @@ import logging
 lgr = logging.getLogger('niceman.resource.base')
 
 
+def get_required_fields(cls):
+    """Return the mandatory fields for a resource class.
+    """
+    return {f.name for f in attr.fields(cls) if f.default is attr.NOTHING}
+
+
 def get_resource_backends(cls):
     """Return name to documentation mapping of `cls`s backends.
     """
@@ -39,23 +45,27 @@ def get_resource_backends(cls):
             if "doc" in b.metadata}
 
 
-def backend_set_config(params, env_resource, config):
-    """Set backend parameters in resource instance and config.
+def backend_check_parameters(cls, keys):
+    """Check whether any backend parameter keys are unknown.
 
     Parameters
     ----------
-    params : dict
-        Backend parameters.
-    env_resource : Resource object
-    config : dict
-        Configuration parameters for the resource.
+    cls : Resource object
+    keys : iterable
+        Backend parameter keys to check.
+
+    Raises
+    ------
+    ResourceError on the first unknown key encountered.
     """
-    for key, value in params.items():
-        if hasattr(env_resource, key):
-            config[key] = value
-            setattr(env_resource, key, value)
-        else:
-            known = get_resource_backends(env_resource.__class__)
+    required_params = get_required_fields(cls)
+    for req_param in required_params:
+        if req_param not in keys:
+            raise ResourceError(
+                "Missing required backend parameter: " + req_param)
+    known = get_resource_backends(cls)
+    for key in keys:
+        if key not in known and key not in required_params:
             if known:
                 import difflib
 
@@ -73,8 +83,7 @@ def backend_set_config(params, env_resource, config):
                                for bname, bdoc in sorted(params.items())]))
                 msg = "Bad --backend parameter '{}'{}".format(key, help_msg)
             else:
-                msg = "Resource type {!r} has no known parameters".format(
-                    env_resource.type)
+                msg = "Resource {} has no known parameters".format(cls)
             raise ResourceError(msg)
 
 
@@ -137,7 +146,14 @@ class ResourceManager(object):
                     exc_str(exc),
                     ', '.join(ResourceManager._discover_types()))
             )
-        instance = getattr(module, class_name)(**config)
+        cls = getattr(module, class_name)
+        try:
+            instance = cls(**config)
+        except TypeError:
+            backend_check_parameters(cls, config)
+            # The check didn't raise an exception, so this wasn't related to an
+            # unknown backend parameter.
+            raise
         return instance
 
     # TODO: Following methods might better be in their own class
@@ -286,9 +302,9 @@ class ResourceManager(object):
                 .format("name" if results_name else "ID", name))
 
         config = {'name': name, 'type': resource_type}
-        resource = self.factory(config)
         if backend_params:
-            backend_set_config(backend_params, resource, config)
+            config.update(backend_params)
+        resource = self.factory(config)
         resource.connect()
         resource_attrs = resource.create()
         config.update(resource_attrs)

--- a/niceman/resource/base.py
+++ b/niceman/resource/base.py
@@ -44,15 +44,13 @@ def backend_set_config(params, env_resource, config):
 
     Parameters
     ----------
-    params : list of str
-        A list of backend parameters, where key value pairs are separated by
-        '='.
+    params : dict
+        Backend parameters.
     env_resource : Resource object
     config : dict
         Configuration parameters for the resource.
     """
-    for backend_arg in params:
-        key, value = backend_arg.split("=")
+    for key, value in params.items():
         if hasattr(env_resource, key):
             config[key] = value
             setattr(env_resource, key, value)

--- a/niceman/resource/base.py
+++ b/niceman/resource/base.py
@@ -285,14 +285,7 @@ class ResourceManager(object):
                 "Resource with {} {} already exists"
                 .format("name" if results_name else "ID", name))
 
-        try:
-            config = dict(
-                self.config_manager.items(resource_type.split('-')[0]))
-        except NoSectionError:
-            config = {}
-
-        config['name'] = name
-        config['type'] = resource_type
+        config = {'name': name, 'type': resource_type}
         resource = self.factory(config)
         if backend_params:
             backend_set_config(backend_params, resource, config)

--- a/niceman/resource/ssh.py
+++ b/niceman/resource/ssh.py
@@ -31,9 +31,7 @@ class SSH(Resource):
     name = attrib(default=attr.NOTHING)
 
     # Configurable options for each "instance"
-    host = attrib(
-        # TODO:  default=attr.NOTHING,
-        doc="DNS or IP address of server")
+    host = attrib(default=attr.NOTHING, doc="DNS or IP address of server")
     port = attrib(
         doc="Port to connect to on remote host")
     key_filename = attrib(

--- a/niceman/resource/tests/test_base.py
+++ b/niceman/resource/tests/test_base.py
@@ -9,7 +9,7 @@ import os.path as op
 import pytest
 
 from niceman.resource.base import ResourceManager
-from niceman.resource.base import backend_set_config
+from niceman.resource.base import backend_check_parameters
 from niceman.resource.shell import Shell
 from niceman.resource.docker_container import DockerContainer
 from niceman.support.exceptions import MissingConfigError
@@ -28,28 +28,34 @@ def test_resource_manager_factory_unkown():
         ResourceManager.factory({"type": "not really a type"})
 
 
-def test_backend_set_config_no_known():
+def test_backend_check_parameters_no_known():
     with pytest.raises(ResourceError) as exc:
-        backend_set_config({"unknown_key": "value"},
-                           Shell(name="test-shell"),
-                           {})
+        backend_check_parameters(Shell,
+                                 {"name": "name",
+                                  "unknown_key": "value"})
     assert "no known parameters" in str(exc.value)
 
 
-def test_backend_set_config_nowhere_close():
+def test_backend_check_parameters_nowhere_close():
     with pytest.raises(ResourceError) as exc:
-        backend_set_config({"unknown_key": "value"},
-                           DockerContainer(name="foo"),
-                           {})
+        backend_check_parameters(DockerContainer,
+                                 {"name": "name",
+                                  "unknown_key": "value"})
     assert "Known backend parameters" in str(exc.value)
 
 
-def test_backend_set_config_close_match():
+def test_backend_check_parameters_close_match():
     with pytest.raises(ResourceError) as exc:
-        backend_set_config({"imagee": "value"},
-                           DockerContainer(name="foo"),
-                           {})
+        backend_check_parameters(DockerContainer,
+                                 {"name": "name",
+                                  "imagee": "value"})
     assert "Did you mean?" in str(exc.value)
+
+
+def test_backend_check_parameters_missing_required():
+    with pytest.raises(ResourceError) as exc:
+        backend_check_parameters(DockerContainer, {"imagee": "value"})
+    assert "Missing required" in str(exc.value)
 
 
 def test_resource_manager_empty_init(tmpdir):

--- a/niceman/resource/tests/test_base.py
+++ b/niceman/resource/tests/test_base.py
@@ -30,7 +30,7 @@ def test_resource_manager_factory_unkown():
 
 def test_backend_set_config_no_known():
     with pytest.raises(ResourceError) as exc:
-        backend_set_config(["unknown_key=value"],
+        backend_set_config({"unknown_key": "value"},
                            Shell(name="test-shell"),
                            {})
     assert "no known parameters" in str(exc.value)
@@ -38,7 +38,7 @@ def test_backend_set_config_no_known():
 
 def test_backend_set_config_nowhere_close():
     with pytest.raises(ResourceError) as exc:
-        backend_set_config(["unknown_key=value"],
+        backend_set_config({"unknown_key": "value"},
                            DockerContainer(name="foo"),
                            {})
     assert "Known backend parameters" in str(exc.value)
@@ -46,7 +46,7 @@ def test_backend_set_config_nowhere_close():
 
 def test_backend_set_config_close_match():
     with pytest.raises(ResourceError) as exc:
-        backend_set_config(["imagee=value"],
+        backend_set_config({"imagee": "value"},
                            DockerContainer(name="foo"),
                            {})
     assert "Did you mean?" in str(exc.value)


### PR DESCRIPTION
-   Pass backend parameters when instantiating the resource classes so that we can declare parameters as required.

-   Mark ssh's `host` as mandatory.

Fixes #300.

(Update: Just realized that 8466f0e also fixes #299.)

---

Are there any other attributes that should be mandatory?
