### PR TITLE
 ENH: resources: Teach get/put to infer destination basename 

### DIFF
--- a/niceman/resource/docker_container.py
+++ b/niceman/resource/docker_container.py
@@ -260,9 +260,8 @@ class DockerSession(POSIXSession):
     def put(self, src_path, dest_path, uid=-1, gid=-1):
         # To copy one or more files to the container, the API recommends
         # to do so with a tar archive. http://docker-py.readthedocs.io/en/1.5.0/api/#copy
+        self._prepare_dest_path(dest_path, local=False)
         dest_dir, dest_basename = os.path.split(dest_path)
-        if not self.exists(dest_dir):
-            self.mkdir(dest_dir, parents=True)
         tar_stream = io.BytesIO()
         tar_file = tarfile.TarFile(fileobj=tar_stream, mode='w')
         tar_file.add(src_path, arcname=dest_basename)
@@ -277,9 +276,8 @@ class DockerSession(POSIXSession):
     @borrowdoc(Session)
     def get(self, src_path, dest_path, uid=-1, gid=-1):
         src_dir, src_basename = os.path.split(src_path)
+        self._prepare_dest_path(dest_path)
         dest_dir, dest_basename = os.path.split(dest_path)
-        if not os.path.exists(dest_dir):
-            os.makedirs(dest_dir)
         stream, stat = self.client.get_archive(self.container, src_path)
         tarball = tarfile.open(fileobj=io.BytesIO(stream.read()))
         tarball.extractall(path=dest_dir)

--- a/niceman/resource/docker_container.py
+++ b/niceman/resource/docker_container.py
@@ -275,9 +275,9 @@ class DockerSession(POSIXSession):
 
     @borrowdoc(Session)
     def get(self, src_path, dest_path, uid=-1, gid=-1):
-        src_dir, src_basename = os.path.split(src_path)
+        src_basename = os.path.basename(src_path)
         self._prepare_dest_path(dest_path)
-        dest_dir, dest_basename = os.path.split(dest_path)
+        dest_dir = os.path.dirname(dest_path)
         stream, stat = self.client.get_archive(self.container, src_path)
         tarball = tarfile.open(fileobj=io.BytesIO(stream.read()))
         tarball.extractall(path=dest_dir)

--- a/niceman/resource/docker_container.py
+++ b/niceman/resource/docker_container.py
@@ -260,7 +260,8 @@ class DockerSession(POSIXSession):
     def put(self, src_path, dest_path, uid=-1, gid=-1):
         # To copy one or more files to the container, the API recommends
         # to do so with a tar archive. http://docker-py.readthedocs.io/en/1.5.0/api/#copy
-        self._prepare_dest_path(dest_path, local=False, absolute_only=True)
+        dest_path = self._prepare_dest_path(src_path, dest_path,
+                                            local=False, absolute_only=True)
         dest_dir, dest_basename = os.path.split(dest_path)
         tar_stream = io.BytesIO()
         tar_file = tarfile.TarFile(fileobj=tar_stream, mode='w')
@@ -274,9 +275,9 @@ class DockerSession(POSIXSession):
             self.chown(dest_path, uid, gid)
 
     @borrowdoc(Session)
-    def get(self, src_path, dest_path, uid=-1, gid=-1):
-        src_basename = os.path.basename(src_path)
-        self._prepare_dest_path(dest_path)
+    def get(self, src_path, dest_path=None, uid=-1, gid=-1):
+        src_dir, src_basename = os.path.split(src_path)
+        dest_path = self._prepare_dest_path(src_path, dest_path)
         dest_dir = os.path.dirname(dest_path)
         stream, stat = self.client.get_archive(self.container, src_path)
         tarball = tarfile.open(fileobj=io.BytesIO(stream.read()))

--- a/niceman/resource/docker_container.py
+++ b/niceman/resource/docker_container.py
@@ -260,7 +260,7 @@ class DockerSession(POSIXSession):
     def put(self, src_path, dest_path, uid=-1, gid=-1):
         # To copy one or more files to the container, the API recommends
         # to do so with a tar archive. http://docker-py.readthedocs.io/en/1.5.0/api/#copy
-        self._prepare_dest_path(dest_path, local=False)
+        self._prepare_dest_path(dest_path, local=False, absolute_only=True)
         dest_dir, dest_basename = os.path.split(dest_path)
         tar_stream = io.BytesIO()
         tar_file = tarfile.TarFile(fileobj=tar_stream, mode='w')

--- a/niceman/resource/session.py
+++ b/niceman/resource/session.py
@@ -300,7 +300,7 @@ class Session(object):
             mkdir = partial(self.mkdir, parents=True)
 
         dest_dir = op.dirname(dest_path)
-        if not exists(dest_dir):
+        if dest_dir and not exists(dest_dir):
             mkdir(dest_dir)
 
     def put(self, src_path, dest_path, uid=-1, gid=-1):

--- a/niceman/resource/session.py
+++ b/niceman/resource/session.py
@@ -38,7 +38,7 @@ class Session(object):
     def __attrs_post_init__(self):
         """
         Maintain both current and future session environments.
-        
+
         For persistent resources, we will save the environment information
         to make it available for sessions beyond the current one.
         """
@@ -75,10 +75,10 @@ class Session(object):
 
     def set_envvar(self, variable, value=None, permanent=False, format=False):
         """Set environment variable(s) to be used within the session
-        
+
         All of them would be exported (TODO: should we allow for non-exported
         ones for some reason?  we aren't really scripting to care about non-exported)
-        
+
         Parameters
         ----------
         variable: str or dict
@@ -116,14 +116,14 @@ class Session(object):
 
     def get_envvars(self, permanent=False):
         """Get stored session environment variables
-        
+
         Parameters
         ----------
         permanent : {bool}, optional
             Indicate that the environment variables that persist across
             sessions should be returned (the default is False, which will
             return the environment variables specific to the current session.)
-        
+
         Returns
         -------
         dict
@@ -146,7 +146,7 @@ class Session(object):
         Parameters
         ----------
         command : str or list
-          Name of the script or composite command (if a list, such as 
+          Name of the script or composite command (if a list, such as
           ["activate", "envname"] in conda) to be "sourced"
         permanent : bool, optional
         diff : bool, optional
@@ -177,7 +177,7 @@ class Session(object):
             environment to execute.
         env : dict, optional
             Additional environment variables which are applied
-            only to the current call.  If value is None -- variable will be 
+            only to the current call.  If value is None -- variable will be
             removed
         cwd : string, optional
             Path of directory in which to run the command
@@ -209,7 +209,7 @@ class Session(object):
             environment to execute.
         env : dict, optional
             Additional environment variables which are applied
-            only to the current call.  If value is None -- variable will be 
+            only to the current call.  If value is None -- variable will be
             removed
         cwd : string, optional
             Path of directory in which to run the command
@@ -234,14 +234,14 @@ class Session(object):
 
     def niceman_exec(self, command, args):
         """Run a niceman utility "exec" command in the environment
-        
+
         Parameters
         ----------
         command : string
             The session method name to run. (e.g. mkdir, chown, etc.)
         args : list of strings
             Arguments passed in from the command line for the command
-        
+
         Raises
         ------
         CommandError
@@ -267,12 +267,12 @@ class Session(object):
 
     def exists(self, path):
         """Determine if a path exists in the resource.
-        
+
         Parameters
         ----------
         path : string
             Path to check for existence in the resource environment.
-        
+
         Returns
         -------
         bool
@@ -285,7 +285,7 @@ class Session(object):
 
         The src_path and dest_path must include the name of the file being
         transferred.
-        
+
         Parameters
         ----------
         src_path : string
@@ -306,7 +306,7 @@ class Session(object):
 
         The src_path and dest_path must include the name of the file being
         transferred.
-        
+
         Parameters
         ----------
         src_path : string
@@ -324,12 +324,12 @@ class Session(object):
 
     def get_mtime(self, path):
         """Returns the modification time for a file in the resource
-        
+
         Parameters
         ----------
         path : string
             Path to file on resource
-        
+
         Returns
         -------
         string
@@ -343,14 +343,14 @@ class Session(object):
     #
     def read(self, path, mode='r'):
         """Return content of a file
-        
+
         Parameters
         ----------
         path : string
             Filesystem path to file to be read
         mode : string, optional
             Access mode when reading file (the default is 'r', which is read-only)
-        
+
         Returns
         -------
         list of strings
@@ -360,7 +360,7 @@ class Session(object):
 
     def mkdir(self, path, parents=False):
         """Create a directory
-        
+
         Parameters
         ----------
         path : string
@@ -382,12 +382,12 @@ class Session(object):
 
     def isdir(self, path):
         """Return True if path is pointing to a directory
-        
+
         Parameters
         ----------
         path : string
             Path to test in the resource
-        
+
         Returns
         -------
         bool
@@ -397,7 +397,7 @@ class Session(object):
 
     def chmod(self, path, mode, recursive=False):
         """Set the mode of the indicated path
-        
+
         Parameters
         ----------
         path : string
@@ -412,7 +412,7 @@ class Session(object):
 
     def chown(self, path, uid=-1, gid=-1, recursive=False, remote=True):
         """Set the owner and group ownership of a file or directory.
-        
+
         Parameters
         ----------
         path : string
@@ -438,7 +438,7 @@ class Session(object):
 @attr.s
 class POSIXSession(Session):
     """A Session which relies on commands present in any POSIX-compliant env
-    
+
     """
 
     # -0 is not provided by busybox's env command.  So if we decide to make it
@@ -454,12 +454,12 @@ class POSIXSession(Session):
 
     def _parse_envvars_output(self, out):
         """Decode a JSON string into an object
-        
+
         Parameters
         ----------
         out : string
             JSON string to decode.
-        
+
         Returns
         -------
         object
@@ -647,7 +647,7 @@ class POSIXSession(Session):
         else:
             # Run on the local file system
             Runner().run(command)
-            
+
 
 def get_local_session(env={'LC_ALL': 'C'}, pty=False, shared=None):
     """A shortcut to get a local session"""
@@ -663,7 +663,7 @@ def get_local_session(env={'LC_ALL': 'C'}, pty=False, shared=None):
 
 def get_updated_env(env, update):
     """Given an environment and set of updates, return updated one
-    
+
     Special handling -- keys with None for the value, will be removed
     """
     env_ = updated(env, update)

--- a/niceman/resource/session.py
+++ b/niceman/resource/session.py
@@ -13,8 +13,10 @@ import logging
 lgr = logging.getLogger('niceman.resource.session')
 
 import attr
+from functools import partial
 import json
 import os
+import os.path as op
 import re
 
 from niceman.support.exceptions import SessionRuntimeError
@@ -279,6 +281,27 @@ class Session(object):
             True if path exists
         """
         raise NotImplementedError
+
+    def _prepare_dest_path(self, dest_path, local=True):
+        """Do common handling for the destination target of `get` and `put`.
+
+        Parameters
+        ----------
+        dest_path : str
+            Path to target file.
+        local : bool, optional
+            Whether the destination is on the local machine.
+        """
+        if local:
+            exists = op.exists
+            mkdir = os.makedirs
+        else:
+            exists = self.exists
+            mkdir = partial(self.mkdir, parents=True)
+
+        dest_dir, dest_basename = op.split(dest_path)
+        if not exists(dest_dir):
+            mkdir(dest_dir)
 
     def put(self, src_path, dest_path, uid=-1, gid=-1):
         """Take file on the local file system and copy over into the resource

--- a/niceman/resource/session.py
+++ b/niceman/resource/session.py
@@ -310,7 +310,8 @@ class Session(object):
             mkdir = partial(self.mkdir, parents=True)
 
         if absolute_only and not op.isabs(dest_path):
-            raise ValueError("Destination path must be absolute")
+            raise ValueError(
+                "Destination path must be absolute, got {}".format(dest_path))
 
         dest_dir = dest_base = None
         if dest_path:

--- a/niceman/resource/session.py
+++ b/niceman/resource/session.py
@@ -282,7 +282,7 @@ class Session(object):
         """
         raise NotImplementedError
 
-    def _prepare_dest_path(self, dest_path, local=True):
+    def _prepare_dest_path(self, dest_path, local=True, absolute_only=False):
         """Do common handling for the destination target of `get` and `put`.
 
         Parameters
@@ -291,6 +291,8 @@ class Session(object):
             Path to target file.
         local : bool, optional
             Whether the destination is on the local machine.
+        absolute_only : bool, optional
+            Whether `dest_path` is required to be absolute.
         """
         if local:
             exists = op.exists
@@ -298,6 +300,9 @@ class Session(object):
         else:
             exists = self.exists
             mkdir = partial(self.mkdir, parents=True)
+
+        if absolute_only and not op.isabs(dest_path):
+            raise ValueError("Destination path must be absolute")
 
         dest_dir = op.dirname(dest_path)
         if dest_dir and not exists(dest_dir):

--- a/niceman/resource/session.py
+++ b/niceman/resource/session.py
@@ -299,7 +299,7 @@ class Session(object):
             exists = self.exists
             mkdir = partial(self.mkdir, parents=True)
 
-        dest_dir, dest_basename = op.split(dest_path)
+        dest_dir = op.dirname(dest_path)
         if not exists(dest_dir):
             mkdir(dest_dir)
 

--- a/niceman/resource/shell.py
+++ b/niceman/resource/shell.py
@@ -83,8 +83,8 @@ class ShellSession(POSIXSession):
                         msg="Failed to make directory {}".format(path))
 
     @borrowdoc(Session)
-    def get(self, src_path, dest_path, uid=-1, gid=-1):
-        self._prepare_dest_path(dest_path)
+    def get(self, src_path, dest_path=None, uid=-1, gid=-1):
+        dest_path = self._prepare_dest_path(src_path, dest_path)
         shutil.copy(src_path, dest_path)
         if uid > -1 or gid > -1:
             self.chown(dest_path, uid, gid, recursive=True)

--- a/niceman/resource/shell.py
+++ b/niceman/resource/shell.py
@@ -84,9 +84,7 @@ class ShellSession(POSIXSession):
 
     @borrowdoc(Session)
     def get(self, src_path, dest_path, uid=-1, gid=-1):
-        dest_dir, dest_basename = os.path.split(dest_path)
-        if not self.exists(dest_dir):
-            self.mkdir(dest_dir, parents=True)
+        self._prepare_dest_path(dest_path)
         shutil.copy(src_path, dest_path)
         if uid > -1 or gid > -1:
             self.chown(dest_path, uid, gid, recursive=True)

--- a/niceman/resource/singularity.py
+++ b/niceman/resource/singularity.py
@@ -182,8 +182,7 @@ class SingularitySession(POSIXSession):
 
     @borrowdoc(Session)
     def put(self, src_path, dest_path, uid=-1, gid=-1):
-        dest_dir, _ = os.path.split(dest_path)
-        self.mkdir(dest_dir, parents=True)
+        self._prepare_dest_path(dest_path, local=False)
         cmd = 'cat {} | singularity exec instance://{} tee {} > /dev/null'
         self._runner.run(cmd.format(src_path, self.name, dest_path))
 
@@ -192,9 +191,7 @@ class SingularitySession(POSIXSession):
 
     @borrowdoc(Session)
     def get(self, src_path, dest_path, uid=-1, gid=-1):
-        dest_dir, _ = os.path.split(dest_path)
-        if not os.path.exists(dest_dir):
-            os.makedirs(dest_dir)
+        self._prepare_dest_path(dest_path)
         cmd = 'singularity exec instance://{} cat {} > {}'
         self._runner.run(cmd.format(self.name, src_path, dest_path))
 

--- a/niceman/resource/singularity.py
+++ b/niceman/resource/singularity.py
@@ -182,7 +182,8 @@ class SingularitySession(POSIXSession):
 
     @borrowdoc(Session)
     def put(self, src_path, dest_path, uid=-1, gid=-1):
-        self._prepare_dest_path(dest_path, local=False, absolute_only=True)
+        dest_path = self._prepare_dest_path(src_path, dest_path,
+                                            local=False, absolute_only=True)
         cmd = 'cat {} | singularity exec instance://{} tee {} > /dev/null'
         self._runner.run(cmd.format(src_path, self.name, dest_path))
 
@@ -190,8 +191,8 @@ class SingularitySession(POSIXSession):
             self.chown(dest_path, uid, gid)
 
     @borrowdoc(Session)
-    def get(self, src_path, dest_path, uid=-1, gid=-1):
-        self._prepare_dest_path(dest_path)
+    def get(self, src_path, dest_path=None, uid=-1, gid=-1):
+        dest_path = self._prepare_dest_path(src_path, dest_path)
         cmd = 'singularity exec instance://{} cat {} > {}'
         self._runner.run(cmd.format(self.name, src_path, dest_path))
 

--- a/niceman/resource/singularity.py
+++ b/niceman/resource/singularity.py
@@ -182,7 +182,7 @@ class SingularitySession(POSIXSession):
 
     @borrowdoc(Session)
     def put(self, src_path, dest_path, uid=-1, gid=-1):
-        self._prepare_dest_path(dest_path, local=False)
+        self._prepare_dest_path(dest_path, local=False, absolute_only=True)
         cmd = 'cat {} | singularity exec instance://{} tee {} > /dev/null'
         self._runner.run(cmd.format(src_path, self.name, dest_path))
 

--- a/niceman/resource/ssh.py
+++ b/niceman/resource/ssh.py
@@ -156,9 +156,7 @@ class SSHSession(POSIXSession):
 
     @borrowdoc(Session)
     def put(self, src_path, dest_path, uid=-1, gid=-1):
-        dest_dir, _ = os.path.split(dest_path)
-        if not self.exists(dest_dir):
-            self.mkdir(dest_dir, parents=True)
+        self._prepare_dest_path(dest_path, local=False)
         self.connection.put(src_path, dest_path)
 
         if uid > -1 or gid > -1:
@@ -166,9 +164,7 @@ class SSHSession(POSIXSession):
 
     @borrowdoc(Session)
     def get(self, src_path, dest_path, uid=-1, gid=-1):
-        dest_dir, _ = os.path.split(dest_path)
-        if not os.path.exists(dest_dir):
-            os.makedirs(dest_dir)
+        self._prepare_dest_path(dest_path)
         self.connection.get(src_path, dest_path)
 
         if uid > -1 or gid > -1:

--- a/niceman/resource/ssh.py
+++ b/niceman/resource/ssh.py
@@ -156,15 +156,15 @@ class SSHSession(POSIXSession):
 
     @borrowdoc(Session)
     def put(self, src_path, dest_path, uid=-1, gid=-1):
-        self._prepare_dest_path(dest_path, local=False)
+        dest_path = self._prepare_dest_path(src_path, dest_path, local=False)
         self.connection.put(src_path, dest_path)
 
         if uid > -1 or gid > -1:
             self.chown(dest_path, uid, gid)
 
     @borrowdoc(Session)
-    def get(self, src_path, dest_path, uid=-1, gid=-1):
-        self._prepare_dest_path(dest_path)
+    def get(self, src_path, dest_path=None, uid=-1, gid=-1):
+        dest_path = self._prepare_dest_path(src_path, dest_path)
         self.connection.get(src_path, dest_path)
 
         if uid > -1 or gid > -1:

--- a/niceman/resource/tests/test_session.py
+++ b/niceman/resource/tests/test_session.py
@@ -19,7 +19,7 @@ import uuid
 from ..session import get_updated_env, Session
 from ...support.exceptions import CommandError
 from ..docker_container import DockerSession, PTYDockerSession
-from ...utils import swallow_logs
+from ...utils import chpwd, swallow_logs
 from ..shell import ShellSession
 from ..singularity import Singularity, SingularitySession, \
     PTYSingularitySession
@@ -350,6 +350,11 @@ def test_session_abstract_methods(testing_container, resource_session,
         assert content[0] == 'NICEMAN test content'
     os.remove(local_path)
     os.rmdir(os.path.dirname(local_path))
+
+    with chpwd(resource_test_dir):
+        # We can get() without a leading directory.
+        session.get(remote_path, "just-base")
+        assert os.path.exists("just-base")
 
     # Check mkdir() method
     test_dir = '{}/{}'.format(resource_test_dir, uuid.uuid4().hex)

--- a/niceman/resource/tests/test_session.py
+++ b/niceman/resource/tests/test_session.py
@@ -367,6 +367,13 @@ def test_session_abstract_methods(testing_container, resource_session,
         # We can get() without a leading directory.
         session.get(remote_path, "just-base")
         assert os.path.exists("just-base")
+        remote_basename = os.path.basename(remote_path)
+        # We can get() without specifying a target.
+        session.get(remote_path)
+        assert os.path.exists(remote_basename)
+        # Or by specifying just the directory.
+        session.get(remote_path, "subdir" + os.path.sep)
+        assert os.path.exists(os.path.join("subdir", remote_basename))
 
     # Check mkdir() method
     test_dir = '{}/{}'.format(resource_test_dir, uuid.uuid4().hex)

--- a/niceman/resource/tests/test_session.py
+++ b/niceman/resource/tests/test_session.py
@@ -327,6 +327,18 @@ def test_session_abstract_methods(testing_container, resource_session,
         assert result
         # TODO: Check uid and gid of remote file
 
+        # We can use a relative name for the target
+        basename_put_dir = os.path.join(resource_test_dir, "basename-put")
+        if not os.path.exists(basename_put_dir):
+            os.mkdir(basename_put_dir)
+        # Change directory to avoid polluting test directory for local shell.
+        with chpwd(basename_put_dir):
+            try:
+                session.put(local_path, os.path.basename(remote_path))
+            except ValueError:
+                # Docker and Singularity don't accept non-absolute paths.
+                assert isinstance(session, (DockerSession, SingularitySession))
+
     # Check get_mtime() method by checking new file has today's date
     result = int(session.get_mtime(remote_path).split('.')[0])
     assert datetime.datetime.fromtimestamp(result).month == \


### PR DESCRIPTION
This mostly addresses #295, but it looks like the particular example that issue gave still won't work because `AwsEc2` doesn't define a `get()` method.

---

- [x] fix failing tests