### PR TITLE
ENH: singularity: Expect failures when running commands

### DIFF
--- a/niceman/resource/singularity.py
+++ b/niceman/resource/singularity.py
@@ -174,8 +174,9 @@ class SingularitySession(POSIXSession):
         # If command is a string, convert it to a list
         if isinstance(command, six.string_types):
             command = command.split()
-        stdout, stderr = self._runner.run(['singularity', 'exec',
-            'instance://' + self.name] + command)
+        stdout, stderr = self._runner.run(
+            ['singularity', 'exec', 'instance://' + self.name] + command,
+            expect_fail=True)
 
         return (stdout, stderr)
 


### PR DESCRIPTION
```
Pass expect_fail=True to the runner calls to prevent methods like
exists() from unnecessarily worrying the user with things like

    [ERROR  ] stderr| cat: /no/such/file: No such file or directory

Using expect_fail=True here is consistent with
ShellSession._execute_command().
```