### PR TITLE
 TST: resource: Prevent proliferation of Singularity instances

### DIFF
--- a/niceman/resource/tests/test_session.py
+++ b/niceman/resource/tests/test_session.py
@@ -213,7 +213,7 @@ def resource_session(request):
     request : object
         Pytest request object that contains the class to test against
 
-    Returns
+    Yields
     -------
     session object
         Instantiated object based on a class that extends the Session or

--- a/niceman/resource/tests/test_session.py
+++ b/niceman/resource/tests/test_session.py
@@ -226,10 +226,9 @@ def resource_session(request):
             c for c in client.containers()
             if '/testing-container' in c['Names']
         ][0]
-        return request.param(client, container)
-
-    # Initialize SSH connection to testing Docker container.
-    if request.param in [SSHSession, PTYSSHSession]:
+        yield request.param(client, container)
+    elif request.param in [SSHSession, PTYSSHSession]:
+        # Initialize SSH connection to testing Docker container.
         connection = Connection(
             'localhost',
             user='root',
@@ -239,17 +238,17 @@ def resource_session(request):
             }
         )
         connection.open()
-        return request.param(connection)
-
-    # Initialize Singularity test container.
-    if request.param in [SingularitySession, PTYSingularitySession]:
+        yield request.param(connection)
+    elif request.param in [SingularitySession, PTYSingularitySession]:
+        # Initialize Singularity test container.
         name = str(uuid.uuid4().hex)[:11]
         resource = Singularity(name=name, image='docker://python:2.7')
         resource.connect()
         resource.create()
-        return request.param(name)
+        yield request.param(name)
+    else:
+        yield request.param()
 
-    return request.param()
 
 
 def test_session_abstract_methods(testing_container, resource_session,

--- a/niceman/resource/tests/test_session.py
+++ b/niceman/resource/tests/test_session.py
@@ -246,6 +246,7 @@ def resource_session(request):
         resource.connect()
         resource.create()
         yield request.param(name)
+        resource.delete()
     else:
         yield request.param()
 


### PR DESCRIPTION
```
Adjust the resource_session fixture to delete singularity instances so
that they don't pollute the user's list of running instances.  Without
this, each run of test_session_abstract_methods with
SingularitySession adds entries like

  $ singularity instance.list
  DAEMON NAME      PID      CONTAINER IMAGE
  70ee38d1a70      21382    /tmp/.singularity-runtime.EcWxJv4l/python:2.7
  e9eed6fafdb      20911    /tmp/.singularity-runtime.zeQVjAch/python:2.7
```