### PR TITLE
ENH: Don't list resources if loading a known resource fails

### DIFF
--- a/niceman/resource/base.py
+++ b/niceman/resource/base.py
@@ -134,10 +134,13 @@ class ResourceManager(object):
         except Exception as exc:
             # Typically it should be an ImportError, but let's catch and recast
             # anything just in case.
-            msg = exc_str(exc)
-            known = ResourceManager._discover_types()
-            if module_name not in known:
-                msg += ". Known ones are: {}".format(", ".join(known))
+            try:
+                msg = exc_str(exc)
+                known = ResourceManager._discover_types()
+                if module_name not in known:
+                    msg += ". Known ones are: {}".format(", ".join(known))
+            except Exception as exc2:
+                msg += ".  Failed to discover resource types: " + exc_str(exc2)
             raise ResourceError(
                 "Failed to import resource: {}".format(msg)
             )

--- a/niceman/resource/base.py
+++ b/niceman/resource/base.py
@@ -134,10 +134,12 @@ class ResourceManager(object):
         except Exception as exc:
             # Typically it should be an ImportError, but let's catch and recast
             # anything just in case.
+            msg = exc_str(exc)
+            known = ResourceManager._discover_types()
+            if module_name not in known:
+                msg += ". Known ones are: {}".format(", ".join(known))
             raise ResourceError(
-                "Failed to import resource: {}.  Known ones are: {}".format(
-                    exc_str(exc),
-                    ', '.join(ResourceManager._discover_types()))
+                "Failed to import resource: {}".format(msg)
             )
         instance = getattr(module, class_name)(**config)
         return instance


### PR DESCRIPTION
Usually importing a resource fails because the user has passed an
unknown resource type, so we report the known resources in the
exception message.  But if the import of a known resource fails (e.g.,
because the resource imports an uninstalled module), it's confusing to
show a list of known resources.

Closes #297.