### PR TITLE
BF: Fixed issues with creating a singularity resource

### DIFF
--- a/niceman/interface/exec.py
+++ b/niceman/interface/exec.py
@@ -219,7 +219,7 @@ class Exec(Interface):
             sys.stderr.write(err)
         if error:
             lgr.error(
-                "Command %s failed to run in %s",
-                command, env_resource
+                "Command %s failed to run in %s: %s",
+                command, env_resource.name, error.msg
             )
             raise SystemExit(error.code)

--- a/niceman/resource/tests/test_singularity.py
+++ b/niceman/resource/tests/test_singularity.py
@@ -42,14 +42,14 @@ def test_singularity_resource_class():
         assert resource.id is None
         assert resource.status is None
         resource.create()
-        assert resource.id == 'foo'
+        assert resource.id.startswith('foo-')
         assert resource.status == 'running'
 
         # Test trying to create an already running instance.
         resource_duplicate = Singularity(name='foo',
             image='shub://truatpasteurdotfr/singularity-alpine')
         resource_duplicate.connect()
-        assert resource_duplicate.id == 'foo'
+        assert resource_duplicate.id.startswith('foo-')
         assert resource_duplicate.status == 'running'
         resource_duplicate.create()
         assert_in('Resource foo already exists.', log.lines)


### PR DESCRIPTION
Fixed 2 issues with the singularity resource:

1. When creating a new singularity resource, the name and id of the resource were getting the same value which is problematic when retrieving the resource config info.

2. Unsightly and false-positive ERROR messages were being displayed from the singularity get_instance_info() method.