### PR TITLE
ENH: create: Teach parse_backend_parameters how to handle a mapping

### DIFF
--- a/niceman/interface/create.py
+++ b/niceman/interface/create.py
@@ -24,7 +24,11 @@ lgr = getLogger('niceman.api.create')
 
 
 def parse_backend_parameters(params):
-    return dict(p.split("=", 1) for p in params)
+    if params:
+        res = dict(p.split("=", 1) for p in params)
+    else:
+        res = {}
+    return res
 
 
 class Create(Interface):
@@ -114,7 +118,7 @@ class Create(Interface):
         # TODO: Add ability to clone a resource.
 
         get_manager().create(name, resource_type,
-                             parse_backend_parameters(backend_parameters or []))
+                             parse_backend_parameters(backend_parameters))
         lgr.info("Created the environment %s", name)
 
         # TODO: at the end install packages using install and created env

--- a/niceman/interface/create.py
+++ b/niceman/interface/create.py
@@ -24,6 +24,17 @@ lgr = getLogger('niceman.api.create')
 
 
 def parse_backend_parameters(params):
+    """Parse a list of backend parameters.
+
+    Parameters
+    ----------
+    params : sequence of str
+        Each item should have the form "<key>=<value".
+
+    Returns
+    -------
+    A dict that maps from backend key to value.
+    """
     if params:
         res = dict(p.split("=", 1) for p in params)
     else:

--- a/niceman/interface/create.py
+++ b/niceman/interface/create.py
@@ -11,6 +11,8 @@
 
 __docformat__ = 'restructuredtext'
 
+from collections import Mapping
+
 from .base import Interface
 import niceman.interface.base # Needed for test patching
 from ..support.param import Parameter
@@ -28,14 +30,17 @@ def parse_backend_parameters(params):
 
     Parameters
     ----------
-    params : sequence of str
-        Each item should have the form "<key>=<value".
+    params : sequence of str or mapping
+        For a sequence, each item should have the form "<key>=<value".  If
+        `params` is a mapping, it will be returned as is.
 
     Returns
     -------
-    A dict that maps from backend key to value.
+    A mapping from backend key to value.
     """
-    if params:
+    if isinstance(params, Mapping):
+        res = params
+    elif params:
         res = dict(p.split("=", 1) for p in params)
     else:
         res = {}

--- a/niceman/interface/tests/test_create.py
+++ b/niceman/interface/tests/test_create.py
@@ -8,6 +8,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
 
+from collections import OrderedDict
 import logging
 import pytest
 from mock import patch, call, MagicMock
@@ -77,5 +78,11 @@ def test_parse_backend_parameters():
     for value, expected in [(["a=b"], {"a": "b"}),
                             (["a="], {"a": ""}),
                             (["a=c=d"], {"a": "c=d"}),
-                            (["a-b=c d"], {"a-b": "c d"})]:
+                            (["a-b=c d"], {"a-b": "c d"}),
+                            ({"a": "c=d"}, {"a": "c=d"})]:
         assert parse_backend_parameters(value) == expected
+
+    # We leave any mapping be, including not converting an empty mapping to an
+    # empty dict.
+    assert isinstance(parse_backend_parameters(OrderedDict({})),
+                      OrderedDict)


### PR DESCRIPTION
The command line arguments will come in as a ["key=value"] list, but
we should recognize a mapping so that niceman.api.create() callers
aren't forced to construct a list.

Closes #312.
