### PR TITLE
BF: Update SSHSession to handle string command

### DIFF
--- a/niceman/resource/session.py
+++ b/niceman/resource/session.py
@@ -14,7 +14,6 @@ lgr = logging.getLogger('niceman.resource.session')
 
 import attr
 from functools import partial
-import json
 import os
 import os.path as op
 import re

--- a/niceman/resource/session.py
+++ b/niceman/resource/session.py
@@ -174,7 +174,7 @@ class Session(object):
 
         Parameters
         ----------
-        command : list
+        command : list or str
             Shell command string or list of command tokens to send to the
             environment to execute.
         env : dict, optional
@@ -206,7 +206,7 @@ class Session(object):
 
         Parameters
         ----------
-        command : list
+        command : list or str
             Shell command string or list of command tokens to send to the
             environment to execute.
         env : dict, optional

--- a/niceman/resource/session.py
+++ b/niceman/resource/session.py
@@ -17,6 +17,7 @@ from functools import partial
 import os
 import os.path as op
 import re
+from six.moves import shlex_quote
 
 from niceman.support.exceptions import SessionRuntimeError
 from niceman.cmd import Runner
@@ -601,7 +602,7 @@ class POSIXSession(Session):
 
     def exists_command(self, path):
         """Return the command to run for the exists method."""
-        command = ['test', '-e', path, '&&', 'echo', 'Found']
+        command = ['test', '-e', shlex_quote(path), '&&', 'echo', 'Found']
         return ['bash', '-c', ' '.join(command)]
 
     # def lexists(self, path):
@@ -660,7 +661,7 @@ class POSIXSession(Session):
 
     def isdir_command(self, path):
         """Return the command to run for the exists method."""
-        command = ['test', '-d', path, '&&', 'echo', 'Found']
+        command = ['test', '-d', shlex_quote(path), '&&', 'echo', 'Found']
         return ['bash', '-c', ' '.join(command)]
 
     def chmod(self, path, mode, recursive=False):

--- a/niceman/resource/singularity.py
+++ b/niceman/resource/singularity.py
@@ -10,13 +10,13 @@
 
 import attr
 import os
-import six
 from ..cmd import Runner
 from ..dochelpers import borrowdoc
 from ..support.exceptions import CommandError
 from .session import POSIXSession, Session
 from .base import Resource
 from ..utils import attrib
+from ..utils import command_as_string
 
 import logging
 lgr = logging.getLogger('niceman.resource.singularity')
@@ -171,11 +171,9 @@ class SingularitySession(POSIXSession):
         if cwd:
             raise NotImplementedError("handle cwd for singularity")
         lgr.debug('Running command %r', command)
-        # If command is a string, convert it to a list
-        if isinstance(command, six.string_types):
-            command = command.split()
         stdout, stderr = self._runner.run(
-            ['singularity', 'exec', 'instance://' + self.name] + command,
+            "singularity exec instance://{} {}".format(
+                self.name, command_as_string(command)),
             expect_fail=True)
 
         return (stdout, stderr)

--- a/niceman/resource/singularity.py
+++ b/niceman/resource/singularity.py
@@ -10,6 +10,8 @@
 
 import attr
 import os
+from six.moves import shlex_quote
+
 from ..cmd import Runner
 from ..dochelpers import borrowdoc
 from ..support.exceptions import CommandError
@@ -183,7 +185,9 @@ class SingularitySession(POSIXSession):
         dest_path = self._prepare_dest_path(src_path, dest_path,
                                             local=False, absolute_only=True)
         cmd = 'cat {} | singularity exec instance://{} tee {} > /dev/null'
-        self._runner.run(cmd.format(src_path, self.name, dest_path))
+        self._runner.run(cmd.format(shlex_quote(src_path),
+                                    self.name,
+                                    shlex_quote(dest_path)))
 
         if uid > -1 or gid > -1:
             self.chown(dest_path, uid, gid)
@@ -192,7 +196,9 @@ class SingularitySession(POSIXSession):
     def get(self, src_path, dest_path=None, uid=-1, gid=-1):
         dest_path = self._prepare_dest_path(src_path, dest_path)
         cmd = 'singularity exec instance://{} cat {} > {}'
-        self._runner.run(cmd.format(self.name, src_path, dest_path))
+        self._runner.run(cmd.format(self.name,
+                                    shlex_quote(src_path),
+                                    shlex_quote(dest_path)))
 
         if uid > -1 or gid > -1:
             self.chown(dest_path, uid, gid, remote=False)

--- a/niceman/resource/ssh.py
+++ b/niceman/resource/ssh.py
@@ -135,8 +135,11 @@ class SSHSession(POSIXSession):
             # TODO: might not work - not tested it
             # command = ['export %s=%s;' % k for k in command_env.items()] + command
 
+        if isinstance(command, list):
+            command = ' '.join(command)
+
         try:
-            result = self.connection.run(' '.join(command), hide=True)
+            result = self.connection.run(command, hide=True)
         except invoke.exceptions.UnexpectedExit as e:
             result = e.result
 

--- a/niceman/resource/ssh.py
+++ b/niceman/resource/ssh.py
@@ -18,6 +18,7 @@ lgr = logging.getLogger('niceman.resource.ssh')
 
 from .base import Resource
 from ..utils import attrib
+from ..utils import command_as_string
 from niceman.dochelpers import borrowdoc
 from niceman.resource.session import Session
 from ..support.exceptions import CommandError
@@ -135,9 +136,7 @@ class SSHSession(POSIXSession):
             # TODO: might not work - not tested it
             # command = ['export %s=%s;' % k for k in command_env.items()] + command
 
-        if isinstance(command, list):
-            command = ' '.join(command)
-
+        command = command_as_string(command)
         try:
             result = self.connection.run(command, hide=True)
         except invoke.exceptions.UnexpectedExit as e:

--- a/niceman/resource/ssh.py
+++ b/niceman/resource/ssh.py
@@ -12,7 +12,6 @@ import attr
 import invoke
 import uuid
 from fabric import Connection
-import os
 
 import logging
 lgr = logging.getLogger('niceman.resource.ssh')

--- a/niceman/resource/ssh.py
+++ b/niceman/resource/ssh.py
@@ -169,20 +169,6 @@ class SSHSession(POSIXSession):
         if uid > -1 or gid > -1:
             self.chown(dest_path, uid, gid, remote=False)
 
-    @borrowdoc(POSIXSession)
-    def exists_command(self, path):
-        return ['bash', '-c', '"test', '-e', path, '&&', 'echo', 'Found"']
-
-    @borrowdoc(POSIXSession)
-    def isdir_command(self, path):
-        return ['bash', '-c', '"test', '-d', path, '&&', 'echo', 'Found"']
-
-    @borrowdoc(POSIXSession)
-    def get_mtime_command(self, path):
-        return ['python', '-c',
-            '"import os, sys; print(os.path.getmtime(sys.argv[1]))"',
-            path]
-
 
 @attr.s
 class PTYSSHSession(SSHSession):

--- a/niceman/resource/tests/test_session.py
+++ b/niceman/resource/tests/test_session.py
@@ -398,6 +398,19 @@ def test_session_abstract_methods(testing_container, resource_session,
     result = session.isdir(test_dir)
     assert result, "The path %s is not a directory" % test_dir
 
+    # All sessions will take the command in string form...
+    output_string = "{}/stringtest {}".format(
+        resource_test_dir, session.__class__.__name__)
+    assert not session.exists(output_string)
+    session.execute_command("touch '{}'".format(output_string))
+    assert session.exists(output_string)
+    # and the list form.
+    output_list = "{}/listtest {}".format(
+        resource_test_dir, session.__class__.__name__)
+    assert not session.exists(output_list)
+    session.execute_command(["touch", output_list])
+    assert session.exists(output_list)
+
     # TODO: How to test chmod and chown? Need to be able to read remote file attributes
     # session.chmod(self, path, mode, recursive=False):
     # session.chown(self, path, uid=-1, gid=-1, recursive=False, remote=True):

--- a/niceman/resource/tests/test_session.py
+++ b/niceman/resource/tests/test_session.py
@@ -316,7 +316,7 @@ def test_session_abstract_methods(testing_container, resource_session,
         f.write('NICEMAN test content\nline 2\nline 3'.encode('utf8'))
         f.flush()
         local_path = temp_file.name
-        remote_path = '{}/niceman-upload/{}'.format(resource_test_dir,
+        remote_path = '{}/niceman upload/{}'.format(resource_test_dir,
             uuid.uuid4().hex)
 
         # Check put() method
@@ -365,8 +365,8 @@ def test_session_abstract_methods(testing_container, resource_session,
 
     with chpwd(resource_test_dir):
         # We can get() without a leading directory.
-        session.get(remote_path, "just-base")
-        assert os.path.exists("just-base")
+        session.get(remote_path, "just base")
+        assert os.path.exists("just base")
         remote_basename = os.path.basename(remote_path)
         # We can get() without specifying a target.
         session.get(remote_path)
@@ -382,13 +382,13 @@ def test_session_abstract_methods(testing_container, resource_session,
     assert result
 
     # Check making parent dirs without setting flag
-    test_dir = '{}/tmp/failed/{}'.format(resource_test_dir, uuid.uuid4().hex)
+    test_dir = '{}/tmp/i fail/{}'.format(resource_test_dir, uuid.uuid4().hex)
     with pytest.raises(CommandError):
         session.mkdir(test_dir, parents=False)
     result = session.isdir(test_dir)
     assert not result
     # Check making parent dirs when parents flag set
-    test_dir = '{}/success/{}'.format(resource_test_dir, uuid.uuid4().hex)
+    test_dir = '{}/i succeed/{}'.format(resource_test_dir, uuid.uuid4().hex)
     session.mkdir(test_dir, parents=True)
     result = session.isdir(test_dir)
     assert result

--- a/niceman/resource/tests/test_session.py
+++ b/niceman/resource/tests/test_session.py
@@ -301,6 +301,8 @@ def test_session_abstract_methods(testing_container, resource_session,
     assert result
     result = session.exists('/no/such/file')
     assert not result
+    # exists() doesn't get confused by an empty string.
+    assert not session.exists('')
 
     # Check isdir() method
     result = session.isdir('/etc')

--- a/niceman/utils.py
+++ b/niceman/utils.py
@@ -12,6 +12,7 @@ import re
 import six
 
 import six.moves.builtins as __builtin__
+from six.moves import shlex_quote
 import time
 
 from os.path import curdir, basename, exists, realpath, islink, join as opj, isabs, normpath, expandvars, expanduser, abspath
@@ -1253,6 +1254,20 @@ def parse_semantic_version(version):
     else:
         raise ValueError(
             "{} does not appear to follow semantic versioning".format(version))
+
+
+def command_as_string(command):
+    """Convert `command` to the string representation.
+
+    Parameters
+    ----------
+    command : list or str
+        If it is a list, convert it to a string, quoting each element as
+        needed.  If it is a string, it is returned as is.
+    """
+    if isinstance(command, list):
+        command = " ".join(map(shlex_quote, command))
+    return command
 
 
 lgr.log(5, "Done importing niceman.utils")


### PR DESCRIPTION
Main changes: 

* Make it possible to use string commands with SSHSession because this is possible with other sessions and used by internal callers of execute_command().

* Provide better escaping for commands in SSHSession and SingularitySession.

* Provide better escaping for session methods like isdir().  This is unrelated to the initial purpose of this PR, but it was needed for adding the string/list command form tests to test_session_abstract_methods().