### PR TITLE
BF: redhat: Don't instantiate RPMSource with unknown fields

### DIFF
--- a/niceman/distributions/redhat.py
+++ b/niceman/distributions/redhat.py
@@ -328,6 +328,7 @@ class RPMTracer(DistributionTracer):
         -------
         sources : list(RPMSource)
         """
+        attr_fields = {f.name for f in attr.fields(RPMSource)}
         sources = []
         # Get all repo info from the system and store information for each
         # enabled repo in a RPMSource object.
@@ -354,7 +355,11 @@ class RPMTracer(DistributionTracer):
                 else:
                     # Map the field labels returned by the sytem to the attr
                     # fields in the RPMSource class.
-                    values[key.split('-')[1]] = value
+                    field = key.split('-')[1]
+                    if field in attr_fields:
+                        values[field] = value
+                    else:
+                        lgr.warning("Ignoring RPM line: %s", line)
             if len(line) == 0:
                 sources.append(RPMSource(**values))
         return sources


### PR DESCRIPTION
test_redhat.py::test_tracer is failing on Travis with

    TypeError: __init__() got an unexpected keyword argument 'excluded'

Presumably this is due to a change in the Docker image used for this
test.

Instead of dying in such a situation, issue a warning that we've
encountered an unknown field in the 'yum --verbose repolist' output
and continue.  Perhaps we should add an "excluded" attributes to
RPMSource and/or update the test to use a stable Docker image, but we
should still make _find_all_sources resilient to unknown keys to avoid
such failures in the future.