### PR TITLE
CLN+TST: Purge print statements in tests

### DIFF
--- a/niceman/distributions/tests/test_debian.py
+++ b/niceman/distributions/tests/test_debian.py
@@ -11,7 +11,6 @@ import os
 from os.path import islink
 from os.path import join, isfile
 
-from pprint import pprint
 import logging
 
 import attr
@@ -44,7 +43,6 @@ def test_dpkg_manager_identify_packages():
     distributions = list(tracer.identify_distributions(files))
     assert len(distributions) == 1
     distribution, unknown_files = distributions[0]
-    print(json.dumps(attr.asdict(distribution), indent=4))
     assert distribution.apt_sources
     # Make sure both a non-local origin was found
     for o in distribution.apt_sources:
@@ -69,7 +67,6 @@ def test_check_bin_packages():
     distributions = list(tracer.identify_distributions(files))
     assert len(distributions) == 1
     distribution, unknown_files = distributions[0]
-    print(json.dumps(attr.asdict(distribution), indent=4))
     non_local_origins = [o for o in distribution.apt_sources if o.site]
     assert len(non_local_origins) > 0, "A non-local origin must be found"
     for o in non_local_origins:
@@ -130,9 +127,6 @@ def test_utf8_file():
     (packages, unknown_files) = \
         manager.identify_packages_from_files(files)
     packages = manager.get_details_for_packages(packages)
-    # Print for manual debugging
-    pprint(unknown_files)
-    pprint(packages)
     # If the file exists, it should be in ca-certificates
     if os.path.isfile(files[0]):
         assert packages[0].name == "ca-certificates"

--- a/niceman/formats/tests/test_niceman.py
+++ b/niceman/formats/tests/test_niceman.py
@@ -46,7 +46,6 @@ def test_write():
     env_reparsed = NicemanProvenance(out).get_environment()
     # and we could do the full round trip while retaining the same "value"
     assert env == env_reparsed
-    print(out)
 
 
 def test_spec_round_trip():

--- a/niceman/interface/tests/test_retrace_packages.py
+++ b/niceman/interface/tests/test_retrace_packages.py
@@ -7,8 +7,6 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from pprint import pprint
-
 from ..retrace import identify_distributions
 
 
@@ -23,6 +21,4 @@ def test_identify_packages():
              "/home/butch"]
     # Simple sanity check that the pipeline works
     distributions, files = identify_distributions(files)
-    pprint(files)
-    pprint(distributions)
     assert True

--- a/niceman/resource/tests/test_docker_container.py
+++ b/niceman/resource/tests/test_docker_container.py
@@ -161,7 +161,6 @@ def test_dockercontainer_class():
 
 
 def test_setup_ubuntu(setup_ubuntu):
-    print(setup_ubuntu)
     assert setup_ubuntu['container_id']
 
 

--- a/niceman/resource/tests/test_shell.py
+++ b/niceman/resource/tests/test_shell.py
@@ -121,9 +121,6 @@ NON_EXPORTED_VAR=2         # but may be those should be handled??
                                          shell="/bin/bash")
         assert new_env_diff == {}
 
-        # just for "fun"
-        #print ses.source_script([os.path.expanduser('~/anaconda2/bin/activate'), 'datalad'])
-
 
 def test_session_passing_envvars():
     check_session_passing_envvars(ShellSession())
@@ -138,7 +135,6 @@ def test_shell_resource():
     resource = ResourceManager.factory(config)
 
     status = resource.create()
-    print("====================", status)
     assert re.match('\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$', status['id']) is not None
 
     assert type(resource.connect()) == Shell


### PR DESCRIPTION
All of these appear to be meant manual debugging and don't affect the
actual tests.  Remove them so that they don't pollute the test output.
This becomes more important as of 3ef0f5c0 (Added -s switch for pytest
in travis, 2018-09-13) because the test stdout/stderr is dumped to the
Travis logs, making the logs exceed Travis's online display limit.

Closes #322.