### PR TITLE
BF+RF: interface: Rename "exec" to "execute"

### DIFF
--- a/niceman/interface/__init__.py
+++ b/niceman/interface/__init__.py
@@ -27,7 +27,7 @@ _group_dataset = (
         ('niceman.interface.start', 'Start'),
         ('niceman.interface.stop', 'Stop'),
         ('niceman.interface.login', 'Login'),
-        ('niceman.interface.exec', 'Exec'),
+        ('niceman.interface.execute', 'Execute'),
         # ('niceman.distribution.run', 'Run'),
     ])
 

--- a/niceman/interface/execute.py
+++ b/niceman/interface/execute.py
@@ -29,16 +29,16 @@ from .common_opts import resref_opt
 from .common_opts import resref_type_opt
 
 from logging import getLogger
-lgr = getLogger('niceman.api.exec')
+lgr = getLogger('niceman.api.execute')
 
 
-class Exec(Interface):
+class Execute(Interface):
     """Execute a command in a computation environment
 
     Examples
     --------
 
-      $ niceman exec mkdir /home/blah/data
+      $ niceman execute mkdir /home/blah/data
 
     """
 

--- a/niceman/interface/tests/test_execute.py
+++ b/niceman/interface/tests/test_execute.py
@@ -27,7 +27,8 @@ docker_container = skip_ssh(get_docker_fixture)(
     scope='module'
 )
 
-def test_exec_interface(docker_container):
+
+def test_execute_interface(docker_container):
 
     with patch('niceman.resource.ResourceManager._get_inventory') as get_inventory:
         config = {
@@ -43,9 +44,9 @@ def test_exec_interface(docker_container):
             "testing-container": config
         }
 
-        cmd = ['exec', 'mkdir', path, '--resource', 'testing-container']
+        cmd = ['execute', 'mkdir', path, '--resource', 'testing-container']
         manager = ResourceManager()
-        with patch("niceman.interface.exec.get_manager",
+        with patch("niceman.interface.execute.get_manager",
                    return_value=ResourceManager()):
             main(cmd)
 


### PR DESCRIPTION
```
"exec" is a poorly chosen name because it conflicts with the `exec`
statement in Python 2.  Things like

  python2 -c "import niceman.api.exec"
  python2 -c "from niceman.api import exec as nm"
  python2 -c "import niceman.interface.exec as nm_exec"

all fail with syntax errors.
```

I ran into this with #324.  This needs to be resolved in order to handle the Python 2 test errors there.