### PR TITLE
Adjust ABCs to be Py3-compatible

### DIFF
--- a/niceman/distributions/base.py
+++ b/niceman/distributions/base.py
@@ -15,6 +15,7 @@ import collections
 import yaml
 
 from importlib import import_module
+from six import add_metaclass
 from six import viewvalues
 
 from niceman.utils import attrib
@@ -68,11 +69,10 @@ class Package(SpecObject):
         return tuple(getattr(self, a) for a in self._cmp_fields)
 
 
+@add_metaclass(abc.ABCMeta)
 @attr.s
 class Distribution(SpecObject):
     """Base class for distributions"""
-
-    __metaclass__ = abc.ABCMeta
 
     # Actually might want/need to go away since somewhat duplicates the class
     # name and looks awkward
@@ -167,6 +167,7 @@ _register_with_representer(EnvironmentSpec)
 # Note: The following was derived from ReproZip's PkgManager class
 # (Revised BSD License)
 
+@add_metaclass(abc.ABCMeta)
 class DistributionTracer(object):
     """Base class for package trackers.
 
@@ -175,8 +176,6 @@ class DistributionTracer(object):
     pip, ...), VCS repositories or even container images -- something which has
     to be installed to fulfill environment spec
     """
-
-    __metaclass__ = abc.ABCMeta
 
     # Default to being able to handle directories
     HANDLES_DIRS = True

--- a/niceman/distributions/base.py
+++ b/niceman/distributions/base.py
@@ -8,7 +8,6 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Orchestrators helping with management of target environments (remote or local)"""
 
-import os
 import os.path as op
 import abc
 import attr

--- a/niceman/distributions/base.py
+++ b/niceman/distributions/base.py
@@ -194,7 +194,7 @@ class DistributionTracer(object):
 
     @abc.abstractmethod
     def identify_distributions(self, files):
-        raise NotImplementedError()
+        return
 
     # This one assumes that distribution works with "packages"
     # TODO: we might want to create a more specialized sub-class for that purpose
@@ -284,11 +284,11 @@ class DistributionTracer(object):
         to actually create packages while grouping into packages
         (having identical returned packagefield values)
         """
-        raise NotImplementedError
+        return
 
     @abc.abstractmethod
     def _create_package(self, **package_fields):
         """Creates implementation-specific Package object using fields
         provided by _get_packagefields_for_files
         """
-        raise NotImplementedError
+        return

--- a/niceman/distributions/vcs.py
+++ b/niceman/distributions/vcs.py
@@ -66,7 +66,7 @@ class VCSDistribution(Distribution):
     @abc.abstractmethod
     def install_packages(self, session, use_version=True):
         # This is VCS specific
-        raise NotImplementedError()
+        return
 
     def normalize(self):
         pass

--- a/niceman/formats/base.py
+++ b/niceman/formats/base.py
@@ -10,7 +10,6 @@
 
 from importlib import import_module
 import abc
-import attr
 from six import string_types
 
 from ..utils import file_basename

--- a/niceman/formats/base.py
+++ b/niceman/formats/base.py
@@ -55,7 +55,7 @@ class Provenance(object):
 
     @abc.abstractmethod
     def _load(self, source):
-        raise NotImplementedError
+        return
 
     def get_environment(self):
         """Return Environment object 
@@ -140,7 +140,7 @@ class Provenance(object):
     #         os['name']
     #         os['version']
     #     """
-    #     raise NotImplementedError()
+    #     return
 
     def get_base(self):
         # Default

--- a/niceman/formats/base.py
+++ b/niceman/formats/base.py
@@ -10,6 +10,7 @@
 
 from importlib import import_module
 import abc
+from six import add_metaclass
 from six import string_types
 
 from ..utils import file_basename
@@ -30,6 +31,7 @@ from ..distributions.base import EnvironmentSpec
 
 # XXX Is just a file format Adapter which should provide us with functionality
 # to load/store EnvironmentSpec
+@add_metaclass(abc.ABCMeta)
 class Provenance(object):
     """Base class to handle the collection and management of provenance files.
     
@@ -38,8 +40,6 @@ class Provenance(object):
     
     Also should provide helpers such as `get_files` so we could do retracing.
     """
-
-    __metaclass__ = abc.ABCMeta
 
     def __init__(self, source):
         """

--- a/niceman/resource/base.py
+++ b/niceman/resource/base.py
@@ -11,6 +11,7 @@
 import attr
 from importlib import import_module
 import abc
+from six import add_metaclass
 from six.moves.configparser import NoSectionError
 
 import yaml
@@ -324,11 +325,10 @@ class ResourceManager(object):
         self._save()
 
 
+@add_metaclass(abc.ABCMeta)
 class Resource(object):
     """Base class for creating and managing compute resources.
     """
-
-    __metaclass__ = abc.ABCMeta
 
     def __repr__(self):
         return 'Resource({})'.format(self.name)

--- a/niceman/resource/base.py
+++ b/niceman/resource/base.py
@@ -19,13 +19,11 @@ import os
 import os.path as op
 
 from ..dochelpers import exc_str
-from ..support.exceptions import InsufficientArgumentsError
 from ..support.exceptions import ResourceError
 from ..support.exceptions import ResourceNotFoundError
 from ..support.exceptions import ResourceAlreadyExistsError
 from ..support.exceptions import MultipleResourceMatches
-from ..support.exceptions import MissingConfigError, MissingConfigFileError
-from ..ui import ui
+from ..support.exceptions import MissingConfigError
 
 
 import logging

--- a/niceman/resource/base.py
+++ b/niceman/resource/base.py
@@ -92,8 +92,6 @@ class ResourceManager(object):
     Typically a NICEMAN process will have a single ResourceManager instance.
     """
 
-    __metaclass__ = abc.ABCMeta
-
     # The keys which are known to be secret and should not be exposed
     SECRET_KEYS = ('access_key_id', 'secret_access_key')
 

--- a/niceman/resource/base.py
+++ b/niceman/resource/base.py
@@ -432,10 +432,5 @@ class Resource(object):
             Terminal session (the default is False)
         shared : string, optional
             Shared session identifier (the default is None)
-
-        Raises
-        ------
-        NotImplementedError
-            [description]
         """
-        raise NotImplementedError
+        return

--- a/niceman/support/protocol.py
+++ b/niceman/support/protocol.py
@@ -14,9 +14,12 @@ from os import linesep
 import logging
 import time
 
+from six import add_metaclass
+
 lgr = logging.getLogger('niceman.protocol')
 
 
+@add_metaclass(abc.ABCMeta)
 class ProtocolInterface(object):
     """Interface class for protocols used by the Runner.
 
@@ -26,8 +29,6 @@ class ProtocolInterface(object):
 
     ProtocolInterface is iterable as a list of sections.
     """
-
-    __metaclass__ = abc.ABCMeta
 
     def __init__(self):
         self._sections = []

--- a/niceman/support/protocol.py
+++ b/niceman/support/protocol.py
@@ -70,7 +70,7 @@ class ProtocolInterface(object):
           An id of the started section to be used as argument of the
           corresponding call of end_section().
         """
-        raise NotImplementedError
+        return
 
     @abc.abstractmethod
     def end_section(self, id_, exception):
@@ -90,7 +90,7 @@ class ProtocolInterface(object):
         IndexError
           in case `id` is invalid.
         """
-        raise NotImplementedError
+        return
 
     @abc.abstractmethod
     def add_section(self, cmd, exception):
@@ -106,7 +106,7 @@ class ProtocolInterface(object):
         exception: Exception
           The exception raised by the command if any or None otherwise.
         """
-        raise NotImplementedError
+        return
 
     @abc.abstractproperty
     def records_ext_commands(self):
@@ -117,7 +117,7 @@ class ProtocolInterface(object):
         -------
         bool
         """
-        raise NotImplementedError
+        return
 
     @abc.abstractproperty
     def records_callables(self):
@@ -128,7 +128,7 @@ class ProtocolInterface(object):
         -------
         bool
         """
-        raise NotImplementedError
+        return
 
     @abc.abstractproperty
     def do_execute_ext_commands(self):
@@ -139,7 +139,7 @@ class ProtocolInterface(object):
         -------
         bool
         """
-        raise NotImplementedError
+        return
 
     @abc.abstractproperty
     def do_execute_callables(self):
@@ -150,7 +150,7 @@ class ProtocolInterface(object):
         -------
         bool
         """
-        raise NotImplementedError
+        return
 
     def write_to_file(self, file_):
         """Writes the protocol to file.

--- a/niceman/support/protocol.py
+++ b/niceman/support/protocol.py
@@ -9,7 +9,7 @@
 """ Protocolling  command calls.
 """
 
-from abc import ABCMeta, abstractmethod, abstractproperty
+import abc
 from os import linesep
 import logging
 import time
@@ -27,7 +27,7 @@ class ProtocolInterface(object):
     ProtocolInterface is iterable as a list of sections.
     """
 
-    __metaclass__ = ABCMeta
+    __metaclass__ = abc.ABCMeta
 
     def __init__(self):
         self._sections = []
@@ -51,7 +51,7 @@ class ProtocolInterface(object):
 
         return protocol_str
 
-    @abstractmethod
+    @abc.abstractmethod
     def start_section(self, cmd):
         """Starts a new section of the protocol.
 
@@ -71,7 +71,7 @@ class ProtocolInterface(object):
         """
         raise NotImplementedError
 
-    @abstractmethod
+    @abc.abstractmethod
     def end_section(self, id_, exception):
         """Ends the section `id`.
 
@@ -91,7 +91,7 @@ class ProtocolInterface(object):
         """
         raise NotImplementedError
 
-    @abstractmethod
+    @abc.abstractmethod
     def add_section(self, cmd, exception):
         """Adds a section to the protocol.
 
@@ -107,7 +107,7 @@ class ProtocolInterface(object):
         """
         raise NotImplementedError
 
-    @abstractproperty
+    @abc.abstractproperty
     def records_ext_commands(self):
         """Indicates whether or not the protocol is supposed to include
         external command calls.
@@ -118,7 +118,7 @@ class ProtocolInterface(object):
         """
         raise NotImplementedError
 
-    @abstractproperty
+    @abc.abstractproperty
     def records_callables(self):
         """Indicates whether or not the protocol is supposed to include
         calls of python callables.
@@ -129,7 +129,7 @@ class ProtocolInterface(object):
         """
         raise NotImplementedError
 
-    @abstractproperty
+    @abc.abstractproperty
     def do_execute_ext_commands(self):
         """Indicates whether or not the called commands are
         supposed to actually be executed.
@@ -140,7 +140,7 @@ class ProtocolInterface(object):
         """
         raise NotImplementedError
 
-    @abstractproperty
+    @abc.abstractproperty
     def do_execute_callables(self):
         """Indicates whether or not the callables are supposed to actually
         be executed.

--- a/niceman/ui/base.py
+++ b/niceman/ui/base.py
@@ -12,7 +12,7 @@
 
 __docformat__ = 'restructuredtext'
 
-from abc import ABCMeta, abstractmethod
+import abc
 
 from ..utils import auto_repr
 
@@ -21,9 +21,9 @@ from ..utils import auto_repr
 class InteractiveUI(object):
     """Semi-abstract class for interfaces to implement interactive UI"""
 
-    __metaclass__ = ABCMeta
+    __metaclass__ = abc.ABCMeta
 
-    @abstractmethod
+    @abc.abstractmethod
     def question(self, text,
                  title=None, choices=None,
                  default=None,

--- a/niceman/ui/base.py
+++ b/niceman/ui/base.py
@@ -14,14 +14,15 @@ __docformat__ = 'restructuredtext'
 
 import abc
 
+from six import add_metaclass
+
 from ..utils import auto_repr
 
 
 @auto_repr
+@add_metaclass(abc.ABCMeta)
 class InteractiveUI(object):
     """Semi-abstract class for interfaces to implement interactive UI"""
-
-    __metaclass__ = abc.ABCMeta
 
     @abc.abstractmethod
     def question(self, text,


### PR DESCRIPTION
The key patch is 50deea04 (BF: Declare abc.ABCMeta in py3-compatible way).