### PR TITLE
MNT: Avoid use of deprecated inspect.getargspec()

### DIFF
--- a/niceman/interface/base.py
+++ b/niceman/interface/base.py
@@ -184,7 +184,7 @@ def update_docstring_with_parameters(func, params, prefix=None, suffix=None):
     description of its parameters. The Parameter spec needs to match
     the number and names of the callables arguments.
     """
-    from inspect import getargspec
+    from niceman.utils import getargspec
     # get the signature
     ndefaults = 0
     args, varargs, varkw, defaults = getargspec(func)
@@ -231,7 +231,7 @@ class Interface(object):
         # XXX needs safety check for name collisions
         # XXX allow for parser kwargs customization
         parser_kwargs = {}
-        from inspect import getargspec
+        from niceman.utils import getargspec
         # get the signature
         ndefaults = 0
         args, varargs, varkw, defaults = getargspec(cls.__call__)
@@ -281,7 +281,7 @@ class Interface(object):
     @classmethod
     def call_from_parser(cls, args):
         # XXX needs safety check for name collisions
-        from inspect import getargspec
+        from niceman.utils import getargspec
         argnames = getargspec(cls.__call__)[0]
         kwargs = {k: getattr(args, k) for k in argnames if k != 'self'}
         try:

--- a/niceman/support/param.py
+++ b/niceman/support/param.py
@@ -13,7 +13,7 @@ __docformat__ = 'restructuredtext'
 import re
 import textwrap
 import argparse
-from inspect import getargspec
+from niceman.utils import getargspec
 
 from .constraints import expand_constraint_spec
 

--- a/niceman/tests/test_api.py
+++ b/niceman/tests/test_api.py
@@ -9,7 +9,7 @@
 '''Unit tests for Python API functionality.'''
 
 import re
-from inspect import getargspec
+from niceman.utils import getargspec
 import pytest
 
 from .utils import assert_true, assert_false, eq_

--- a/niceman/utils.py
+++ b/niceman/utils.py
@@ -32,7 +32,7 @@ import glob
 import attr
 from functools import wraps
 from time import sleep
-from inspect import getargspec
+import inspect
 
 from niceman.support.exceptions import CommandError
 
@@ -57,6 +57,17 @@ except:  # pragma: no cover
 #
 # Little helpers
 #
+
+# `getargspec` has been deprecated in Python 3.
+if hasattr(inspect, "getfullargspec"):
+    def getargspec(func):
+        """Backward-compatibility wrapper for inspect.getargspec.
+        """
+        # The first four elements in getfullargspec's return value match
+        # getargspec's.
+        return inspect.getfullargspec(func)[:4]
+else:
+    getargspec = inspect.getargspec
 
 
 def get_func_kwargs_doc(func):


### PR DESCRIPTION
inspect.getargspec() was deprecated in Python 3, briefly removed
entirely, and then restored in 37dc2b2883 (Issue #25486: Resurrect
inspect.getargspec in 3.6. Backout a565aad5d6e1., 2016-01-11).

Much if not all of the code we're updating came from DataLad via 3rd.
DataLad has since dealt with this issue.  Add our own compatibility
function because merging in the relevant DataLad bits would require a
lot of work at this point.