### PR TITLE
 TST: execute: Fix skipif condition

### DIFF
--- a/niceman/interface/tests/test_execute.py
+++ b/niceman/interface/tests/test_execute.py
@@ -123,7 +123,7 @@ def test_trace_docker(docker_container, trace_info):
 @pytest.mark.skipif(os.environ.get('NICEMAN_TESTS_NONETWORK'),
                     reason="No network")
 @pytest.mark.skipif("cmd:apt-cache" in external_versions,
-                    reason="Not apt-cache")
+                    reason="No apt-cache")
 def test_trace_local(trace_info):
     with patch("niceman.resource.ResourceManager._get_inventory") as get_inv:
         config = {"status": "running",

--- a/niceman/interface/tests/test_execute.py
+++ b/niceman/interface/tests/test_execute.py
@@ -122,7 +122,7 @@ def test_trace_docker(docker_container, trace_info):
 # TypeError under Python 2.
 @pytest.mark.skipif(os.environ.get('NICEMAN_TESTS_NONETWORK'),
                     reason="No network")
-@pytest.mark.skipif("cmd:apt-cache" in external_versions,
+@pytest.mark.skipif("cmd:apt-cache" not in external_versions,
                     reason="No apt-cache")
 def test_trace_local(trace_info):
     with patch("niceman.resource.ResourceManager._get_inventory") as get_inv:


### PR DESCRIPTION
```
There are two issues with this condition: (1) it was intended to say
"not in" rather than "in" and (2) an ExternalVersions instance's
__contains__(item) always returns False if __getitem__(item) hasn't
been called previously.  The combination of no. 1 and no. 2 means the
test would never be skipped.

No. 2 has been fixed as of DataLad's e71a57aa3 (BF: external_versions:
Make __contains__ work with non-primed items, 2018-12-03) and has been
incorporated via 3rd.

Update the skipif condition accordingly.
```