### PR TITLE
BF: do not blow `ls` when status is None

### DIFF
--- a/niceman/interface/ls.py
+++ b/niceman/interface/ls.py
@@ -55,7 +55,7 @@ class Ls(Interface):
     @staticmethod
     def __call__(verbose=False, refresh=False):
         id_length = 19  # todo: make it possible to output them long
-        template = '{:<20} {:<20} {:<%(id_length)s} {:<10}' % locals()
+        template = '{:<20} {:<20} {:<%(id_length)s} {!s:<10}' % locals()
         ui.message(template.format('RESOURCE NAME', 'TYPE', 'ID', 'STATUS'))
         ui.message(template.format('-------------', '----', '--', '------'))
 

--- a/niceman/interface/tests/test_sequence.py
+++ b/niceman/interface/tests/test_sequence.py
@@ -35,7 +35,7 @@ def test_create_start_stop(tmpdir):
 
     with open(inventory_file) as ifh:
         inventory = yaml.safe_load(ifh)
-    assert inventory["testshell"]["status"] == "N/A"
+    assert inventory["testshell"]["status"] == "available"
 
     with patch("niceman.interface.start.get_manager",
                return_value=rm):

--- a/niceman/resource/shell.py
+++ b/niceman/resource/shell.py
@@ -102,7 +102,10 @@ class Shell(Resource):
     id = attrib()
     type = attrib(default='shell')
 
-    status = attrib()
+    # TODO: standardize status outputs
+    # "available" is chosen in favor of "running", which is to be used
+    # e.g. if we know that this shell is currently in use.
+    status = attrib(default='available')
 
     def create(self):
         """

--- a/niceman/resource/shell.py
+++ b/niceman/resource/shell.py
@@ -121,7 +121,7 @@ class Shell(Resource):
             self.id = Resource._generate_id()
         return {
             'id': self.id,
-            'status': 'N/A'
+            'status': 'available'
         }
 
     def connect(self):


### PR DESCRIPTION
also state "available" for localshell