### PR TITLE
ENH: crude attempt to make "install" work when sudo needed

### DIFF
--- a/niceman/distributions/tests/test_distribution.py
+++ b/niceman/distributions/tests/test_distribution.py
@@ -19,7 +19,7 @@ from niceman.tests.utils import assert_in
 
 def test_distributions(demo1_spec):
 
-    def mock_execute_command(command):
+    def mock_execute_command(command, env=None):
         if isinstance(command, list):
             if command == ['apt-cache', 'policy', 'libc6-dev:amd64']:
                 return (

--- a/niceman/resource/ssh.py
+++ b/niceman/resource/ssh.py
@@ -139,32 +139,46 @@ class SSHSession(POSIXSession):
     connection = attrib(default=attr.NOTHING)
 
     @borrowdoc(Session)
-    def _execute_command(self, command, env=None, cwd=None):
+    def _execute_command(self, command, env=None, cwd=None, handle_permission_denied=True):
         # TODO -- command_env is not used etc...
         # command_env = self.get_updated_env(env)
+        command = command_as_string(command)
         if env:
-            raise NotImplementedError("passing env variables to execution")
+            command = ' '.join(['%s=%s' % k for k in env.items()]) \
+                      + ' ' + command
 
         if cwd:
             raise NotImplementedError("implement cwd support")
-        # if command_env:
-            # TODO: might not work - not tested it
-            # command = ['export %s=%s;' % k for k in command_env.items()] + command
 
-        command = command_as_string(command)
         try:
             result = self.connection.run(command, hide=True)
         except invoke.exceptions.UnexpectedExit as e:
-            result = e.result
+            if 'permission denied' in e.result.stderr.lower() and handle_permission_denied:
+                # Issue warning once
+                if not getattr(self, '_use_sudo_warning', False):
+                    lgr.warning(
+                        "Permission is denied for %s. From now on will use 'sudo' "
+                        "in such cases",
+                        command
+                    )
+                    self._use_sudo_warning = True
+                return self._execute_command(
+                    "sudo " + command,  # there was command_as_string
+                    env=env,
+                    cwd=cwd,
+                    handle_permission_denied=False
+                )
+            else:
+                result = e.result
 
         if result.return_code not in [0, None]:
             msg = "Failed to run %r. Exit code=%d. out=%s err=%s" \
-                % (command, result.return_code, result.stdout, result.stderr)
+                  % (command, result.return_code, result.stdout, result.stderr)
             raise CommandError(str(command), msg, result.return_code,
-                result.stdout, result.stderr)
+                               result.stdout, result.stderr)
         else:
             lgr.log(8, "Finished running %r with status %s", command,
-                result.return_code)
+                    result.return_code)
 
         return (result.stdout, result.stderr)
 

--- a/niceman/resource/tests/test_session.py
+++ b/niceman/resource/tests/test_session.py
@@ -278,7 +278,7 @@ def test_session_abstract_methods(testing_container, resource_session,
 
     # Check _execute_command with env set
     # TODO: Implement env parameter for _execute_command()
-    if session.__class__.__name__ != 'ShellSession':
+    if not isinstance(session, (ShellSession, SSHSession, PTYSSHSession)):
         with pytest.raises(NotImplementedError):
             out, err = session._execute_command(['cat', '/etc/hosts'],
                 env={'NEW_VAR': 'NEW_VAR_VALUE'})


### PR DESCRIPTION
- ssh: Would fall to try running command via `sudo` (eventually we should make it configurable/interactive, for now - just a "feature") if permission denied upon initial run
  - probably should be RFed anyways to be generic across different backends (e.g. shell etc)
  - partially addresses #351 
- Also makes possible to pass (needed) noninteractive DEBIAN_FRONTEND env variable