### PR TITLE
Revert "CLN: resource: Remove unnecessary code"

### DIFF
--- a/niceman/resource/base.py
+++ b/niceman/resource/base.py
@@ -303,7 +303,15 @@ class ResourceManager(object):
                 "Resource with {} {} already exists"
                 .format("name" if results_name else "ID", name))
 
-        config = {'name': name, 'type': resource_type}
+        try:
+            config = dict(
+                self.config_manager.items(resource_type.split('-')[0]))
+        except NoSectionError:
+            config = {}
+
+        config['name'] = name
+        config['type'] = resource_type
+
         if backend_params:
             config.update(backend_params)
         resource = self.factory(config)


### PR DESCRIPTION
This reverts commit e99fdbaa150fde40ea6b72a307b9f5bd29ea12f2.

The analysis in that commit is mistaken.  That code is not
unnecessary.  It retrieves items from the configuration file, not the
inventory file, so the fact that the upstream code ensures the
resource does not exist is irrelevant.

Fixes #347.