### PR TITLE
BF: aws_ec2: Pass key_filename as a list

### DIFF
--- a/niceman/resource/aws_ec2.py
+++ b/niceman/resource/aws_ec2.py
@@ -278,7 +278,7 @@ Please enter a unique name to create a new key-pair or press [enter] to exit"""
             self.name,
             host=self._ec2_instance.public_ip_address,
             user=self.user,
-            key_filename=self.key_filename
+            key_filename=[self.key_filename]
         )
 
         return ssh.get_session(pty=pty, shared=shared)


### PR DESCRIPTION
A string is an acceptable form [*], but using a string rather than a
list leads to an error when fabric merges a configured IdentityFile
value from ssh_config (a fix is proposed in fabric/fabric#1924).

[*] http://docs.fabfile.org/en/2.4/api/connection.html#connect-kwargs-arg